### PR TITLE
Enable ESlint Error check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,11 +42,9 @@ jobs:
 
       - name: Run ESLint (error)
         run: npm run lint:error
-        continue-on-error: true
 
       - name: Run ESLint (all)
         run: npm run lint
-        continue-on-error: true
 
   check-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As a follow-up to https://github.com/d-rec/drec-ui/pull/73 we can now enable the linter checks on CI.