### PR TITLE
feat: allow creating devices with negative coordinates

### DIFF
--- a/src/app/view/device/add-devices/add-devices.component.ts
+++ b/src/app/view/device/add-devices/add-devices.component.ts
@@ -52,7 +52,7 @@ export class AddDevicesComponent {
   public stepHour = 1;
   public stepMinute = 1;
   public stepSecond = 1;
-  numberregex: RegExp = /^[0-9]+(\.[0-9]*)?$/;
+  numberregex: RegExp = /^-?[0-9]+(\.[0-9]*)?$/;
   filteredCountryList: Observable<any[]>[] = [];
   subscription: Subscription;
   filteredOrgList: OrganizationInformation[] = [];


### PR DESCRIPTION
### Description

- Currently, the platform was allowing positive values to be used when creating a device
- I allowed both positive and negative values
- Negative latitude values are for places below the equator
- Negative Longitude values are for places west of the Greenwich meridian


### Issue ticket #448 and [link](https://github.com/orgs/d-rec/projects/2/views/1?pane=issue&itemId=87280071&issue=d-rec%7Cdrec-origin%7C448)


### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] No existing features have been broken without good reason.
- [x] The code style guideline have been followed
- [x] Documentation has been updated to reflect your changes.
