### PR TITLE
Ft/integrate sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Sentry Config File
+.sentryclirc

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Thumbs.db
 
 # Sentry Config File
 .sentryclirc
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "@angular/router": "^15.0.0",
         "@energyweb/issuer": "7.0.1",
         "@energyweb/utils-general": "^11.2.3",
+        "@sentry/angular": "^8.42.0",
+        "@sentry/cli": "^2.39.1",
+        "@sentry/tracing": "^7.114.0",
         "autoprefixer": "^10.4.19",
         "bootstrap": "^5.2.3",
         "braces": "^3.0.3",
@@ -6516,6 +6519,285 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.42.0.tgz",
+      "integrity": "sha512-xzgRI0wglKYsPrna574w1t38aftuvo44gjOKFvPNGPnYfiW9y4m+64kUz3JFbtanvOrKPcaITpdYiB4DeJXEbA==",
+      "dependencies": {
+        "@sentry/core": "8.42.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.42.0.tgz",
+      "integrity": "sha512-dkIw5Wdukwzngg5gNJ0QcK48LyJaMAnBspqTqZ3ItR01STi6Z+6+/Bt5XgmrvDgRD+FNBinflc5zMmfdFXXhvw==",
+      "dependencies": {
+        "@sentry/core": "8.42.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.42.0.tgz",
+      "integrity": "sha512-oNcJEBlDfXnRFYC5Mxj5fairyZHNqlnU4g8kPuztB9G5zlsyLgWfPxzcn1ixVQunth2/WZRklDi4o1ZfyHww7w==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.42.0",
+        "@sentry/core": "8.42.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.42.0.tgz",
+      "integrity": "sha512-XrPErqVhPsPh/oFLVKvz7Wb+Fi2J1zCPLeZCxWqFuPWI2agRyLVu0KvqJyzSpSrRAEJC/XFzuSVILlYlXXSfgA==",
+      "dependencies": {
+        "@sentry-internal/replay": "8.42.0",
+        "@sentry/core": "8.42.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.114.0.tgz",
+      "integrity": "sha512-dOuvfJN7G+3YqLlUY4HIjyWHaRP8vbOgF+OsE5w2l7ZEn1rMAaUbPntAR8AF9GBA6j2zWNoSo8e7GjbJxVofSg==",
+      "dependencies": {
+        "@sentry/core": "7.114.0",
+        "@sentry/types": "7.114.0",
+        "@sentry/utils": "7.114.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.114.0.tgz",
+      "integrity": "sha512-YnanVlmulkjgZiVZ9BfY9k6I082n+C+LbZo52MTvx3FY6RE5iyiPMpaOh67oXEZRWcYQEGm+bKruRxLVP6RlbA==",
+      "dependencies": {
+        "@sentry/types": "7.114.0",
+        "@sentry/utils": "7.114.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/angular": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@sentry/angular/-/angular-8.42.0.tgz",
+      "integrity": "sha512-gQ3gHNw7FadlLEtE57l9AZ2bkW1bVAk8FnbOkpc3NXkBJTKtxWODbhqCGDxGOWplJGzVOJ4EmXU2GHm7APOdwA==",
+      "dependencies": {
+        "@sentry/browser": "8.42.0",
+        "@sentry/core": "8.42.0",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "@angular/common": ">= 14.x <= 19.x",
+        "@angular/core": ">= 14.x <= 19.x",
+        "@angular/router": ">= 14.x <= 19.x",
+        "rxjs": "^6.5.5 || ^7.x"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.42.0.tgz",
+      "integrity": "sha512-lStrEk609KJHwXfDrOgoYVVoFFExixHywxSExk7ZDtwj2YPv6r6Y1gogvgr7dAZj7jWzadHkxZ33l9EOSJBfug==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.42.0",
+        "@sentry-internal/feedback": "8.42.0",
+        "@sentry-internal/replay": "8.42.0",
+        "@sentry-internal/replay-canvas": "8.42.0",
+        "@sentry/core": "8.42.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.39.1.tgz",
+      "integrity": "sha512-JIb3e9vh0+OmQ0KxmexMXg9oZsR/G7HMwxt5BUIKAXZ9m17Xll4ETXTRnRUBT3sf7EpNGAmlQk1xEmVN9pYZYQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.39.1",
+        "@sentry/cli-linux-arm": "2.39.1",
+        "@sentry/cli-linux-arm64": "2.39.1",
+        "@sentry/cli-linux-i686": "2.39.1",
+        "@sentry/cli-linux-x64": "2.39.1",
+        "@sentry/cli-win32-i686": "2.39.1",
+        "@sentry/cli-win32-x64": "2.39.1"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.39.1.tgz",
+      "integrity": "sha512-kiNGNSAkg46LNGatfNH5tfsmI/kCAaPA62KQuFZloZiemTNzhy9/6NJP8HZ/GxGs8GDMxic6wNrV9CkVEgFLJQ==",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.39.1.tgz",
+      "integrity": "sha512-DkENbxyRxUrfLnJLXTA4s5UL/GoctU5Cm4ER1eB7XN7p9WsamFJd/yf2KpltkjEyiTuplv0yAbdjl1KX3vKmEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.39.1.tgz",
+      "integrity": "sha512-5VbVJDatolDrWOgaffsEM7znjs0cR8bHt9Bq0mStM3tBolgAeSDHE89NgHggfZR+DJ2VWOy4vgCwkObrUD6NQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.39.1.tgz",
+      "integrity": "sha512-pXWVoKXCRrY7N8vc9H7mETiV9ZCz+zSnX65JQCzZxgYrayQPJTc+NPRnZTdYdk5RlAupXaFicBI2GwOCRqVRkg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.39.1.tgz",
+      "integrity": "sha512-IwayNZy+it7FWG4M9LayyUmG1a/8kT9+/IEm67sT5+7dkMIMcpmHDqL8rWcPojOXuTKaOBBjkVdNMBTXy0mXlA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.39.1.tgz",
+      "integrity": "sha512-NglnNoqHSmE+Dz/wHeIVRnV2bLMx7tIn3IQ8vXGO5HWA2f8zYJGktbkLq1Lg23PaQmeZLPGlja3gBQfZYSG10Q==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.39.1.tgz",
+      "integrity": "sha512-xv0R2CMf/X1Fte3cMWie1NXuHmUyQPDBfCyIt6k6RPFPxAYUgcqgMPznYwVMwWEA1W43PaOkSn3d8ZylsDaETw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.42.0.tgz",
+      "integrity": "sha512-ac6O3pgoIbU6rpwz6LlwW0wp3/GAHuSI0C5IsTgIY6baN8rOBnlAtG6KrHDDkGmUQ2srxkDJu9n1O6Td3cBCqw==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.114.0.tgz",
+      "integrity": "sha512-eldEYGADReZ4jWdN5u35yxLUSTOvjsiZAYd4KBEpf+Ii65n7g/kYOKAjNl7tHbrEG1EsMW4nDPWStUMk1w+tfg==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.114.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
+      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.114.0.tgz",
+      "integrity": "sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==",
+      "dependencies": {
+        "@sentry/types": "7.114.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sigstore/bundle": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-1.1.0.tgz",
@@ -7400,7 +7682,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -9020,7 +9301,6 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
       "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -12300,7 +12580,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -12873,8 +13152,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -15765,6 +16043,14 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -15800,6 +16086,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -19347,7 +19638,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "prettier:fix": "prettier --write './{src,migrations,test}/**/*{.ts,.tsx}'",
     "lint": "eslint \"{src,migrations,test}/**/*{.ts,.tsx}\"",
     "lint:error": "eslint \"{src,migrations,test}/**/*{.ts,.tsx}\" --quiet",
-    "lint:fix": "eslint \"{src,migrations,test}/**/*{.ts,.tsx}\" --fix"
+    "lint:fix": "eslint \"{src,migrations,test}/**/*{.ts,.tsx}\" --fix",
+    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org na-ssd --project drec-frontend ./ && sentry-cli sourcemaps upload --org na-ssd --project drec-frontend ./"
   },
   "private": true,
   "dependencies": {
@@ -30,6 +31,9 @@
     "@angular/router": "^15.0.0",
     "@energyweb/issuer": "7.0.1",
     "@energyweb/utils-general": "^11.2.3",
+    "@sentry/angular": "^8.42.0",
+    "@sentry/cli": "^2.39.1",
+    "@sentry/tracing": "^7.114.0",
     "autoprefixer": "^10.4.19",
     "bootstrap": "^5.2.3",
     "braces": "^3.0.3",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,14 +1,15 @@
 import { APP_INITIALIZER, ErrorHandler } from '@angular/core';
 import { Router } from '@angular/router';
 import * as Sentry from "@sentry/angular";
+import { environment } from 'src/environments/environment';
 
 Sentry.init({
-    dsn:"https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208",
+    dsn:environment.SENTRY_DNS,
     integrations: [
       Sentry.browserTracingIntegration(),
       Sentry.replayIntegration(),
     ],
-    // autoSessionTracking: false, 
+    autoSessionTracking: false, 
     tracesSampleRate: 1.0,
     tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
     environment: 'development', 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,7 +2,7 @@ import { APP_INITIALIZER, ErrorHandler } from '@angular/core';
 import { Router } from '@angular/router';
 import * as Sentry from '@sentry/angular';
 import { environment } from 'src/environments/environment';
-if (environment.production) {
+if (environment.production || environment.staging) {
   Sentry.init({
     dsn: environment.SENTRY_DNS,
     integrations: [
@@ -14,7 +14,6 @@ if (environment.production) {
     environment: environment.SENTRY_ENV,
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0,
-    enabled: environment.production,
   });
 }
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -11,15 +11,13 @@ if (environment.production) {
     ],
     tracesSampleRate: 1.0,
     tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
-    environment: environment.production
-      ? 'production'
-      : environment.staging
-        ? 'staging'
-        : 'development',
+    environment: environment.SENTRY_ENV,
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0,
+    enabled: environment.production,
   });
 }
+
 export const appConfig: any = {
   providers: [
     {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,28 +1,28 @@
 import { APP_INITIALIZER, ErrorHandler } from '@angular/core';
 import { Router } from '@angular/router';
-import * as Sentry from "@sentry/angular";
+import * as Sentry from '@sentry/angular';
 import { environment } from 'src/environments/environment';
 
 Sentry.init({
-    dsn:environment.SENTRY_DNS,
-    integrations: [
-      Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration(),
-    ],
-    autoSessionTracking: false, 
-    tracesSampleRate: 1.0,
-    tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
-    environment: 'development', 
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
-  });
+  dsn: environment.SENTRY_DNS,
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration(),
+  ],
+  autoSessionTracking: false,
+  tracesSampleRate: 1.0,
+  tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
+  environment: 'development',
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+});
 
 export const appConfig: any = {
   providers: [
     {
       provide: ErrorHandler,
       useValue: Sentry.createErrorHandler({
-        showDialog: false, 
+        showDialog: false,
       }),
     },
     {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -9,7 +9,6 @@ Sentry.init({
     Sentry.browserTracingIntegration(),
     Sentry.replayIntegration(),
   ],
-  autoSessionTracking: false,
   tracesSampleRate: 1.0,
   tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
   environment: 'production',
@@ -21,9 +20,7 @@ export const appConfig: any = {
   providers: [
     {
       provide: ErrorHandler,
-      useValue: Sentry.createErrorHandler({
-        showDialog: false,
-      }),
+      useValue: Sentry.createErrorHandler(),
     },
     {
       provide: Sentry.TraceService,

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,19 +2,23 @@ import { APP_INITIALIZER, ErrorHandler } from '@angular/core';
 import { Router } from '@angular/router';
 import * as Sentry from '@sentry/angular';
 import { environment } from 'src/environments/environment';
-if ( environment.production) {
-Sentry.init({
-  dsn: environment.SENTRY_DNS,
-  integrations: [
-    Sentry.browserTracingIntegration(),
-    Sentry.replayIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-  tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
-  environment: environment.production ? 'production' : environment.staging ? 'staging' : 'development',
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-});
+if (environment.production) {
+  Sentry.init({
+    dsn: environment.SENTRY_DNS,
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration(),
+    ],
+    tracesSampleRate: 1.0,
+    tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
+    environment: environment.production
+      ? 'production'
+      : environment.staging
+        ? 'staging'
+        : 'development',
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+  });
 }
 export const appConfig: any = {
   providers: [

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -12,7 +12,7 @@ Sentry.init({
   autoSessionTracking: false,
   tracesSampleRate: 1.0,
   tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
-  environment: 'development',
+  environment: 'production',
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
 });

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,7 +2,7 @@ import { APP_INITIALIZER, ErrorHandler } from '@angular/core';
 import { Router } from '@angular/router';
 import * as Sentry from '@sentry/angular';
 import { environment } from 'src/environments/environment';
-
+if ( environment.production) {
 Sentry.init({
   dsn: environment.SENTRY_DNS,
   integrations: [
@@ -11,11 +11,11 @@ Sentry.init({
   ],
   tracesSampleRate: 1.0,
   tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
-  environment: 'production',
+  environment: environment.production ? 'production' : environment.staging ? 'staging' : 'development',
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
 });
-
+}
 export const appConfig: any = {
   providers: [
     {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,0 +1,38 @@
+import { APP_INITIALIZER, ErrorHandler } from '@angular/core';
+import { Router } from '@angular/router';
+import * as Sentry from "@sentry/angular";
+
+Sentry.init({
+    dsn:"https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208",
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration(),
+    ],
+    // autoSessionTracking: false, 
+    tracesSampleRate: 1.0,
+    tracePropagationTargets: ['localhost', /^https?:\/\/localhost:\d+/],
+    environment: 'development', 
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+  });
+
+export const appConfig: any = {
+  providers: [
+    {
+      provide: ErrorHandler,
+      useValue: Sentry.createErrorHandler({
+        showDialog: false, 
+      }),
+    },
+    {
+      provide: Sentry.TraceService,
+      deps: [Router],
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => () => {},
+      deps: [Sentry.TraceService],
+      multi: true,
+    },
+  ],
+};

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { ErrorHandler, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -35,6 +35,7 @@ import { UserProfileComponent } from './view/user-profile/user-profile.component
 import { AdminModule } from './view/admin/admin.module';
 import { UserAcceptInvitationComponent } from './view/user-accept-invitation/user-accept-invitation.component';
 import { ApiuserClientReponseComponent } from './view/apiuser-client-reponse/apiuser-client-reponse.component';
+import * as Sentry from "@sentry/angular";
 
 @NgModule({
   declarations: [
@@ -83,6 +84,13 @@ import { ApiuserClientReponseComponent } from './view/apiuser-client-reponse/api
   ],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    {
+      provide: ErrorHandler,
+      useValue: Sentry.createErrorHandler({
+        showDialog:true
+      }),
+   
+    },
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -35,7 +35,7 @@ import { UserProfileComponent } from './view/user-profile/user-profile.component
 import { AdminModule } from './view/admin/admin.module';
 import { UserAcceptInvitationComponent } from './view/user-accept-invitation/user-accept-invitation.component';
 import { ApiuserClientReponseComponent } from './view/apiuser-client-reponse/apiuser-client-reponse.component';
-import * as Sentry from "@sentry/angular";
+import * as Sentry from '@sentry/angular';
 
 @NgModule({
   declarations: [
@@ -87,9 +87,8 @@ import * as Sentry from "@sentry/angular";
     {
       provide: ErrorHandler,
       useValue: Sentry.createErrorHandler({
-        showDialog:true
+        showDialog: true,
       }),
-   
     },
   ],
   bootstrap: [AppComponent],

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
+  staging: false,
   API_URL: 'https://api.drecs.org/api/',
   Explorer_URL: 'https://explorer.energyweb.org',
   SENTRY_DNS:

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,4 +2,5 @@ export const environment = {
   production: true,
   API_URL: 'https://api.drecs.org/api/',
   Explorer_URL: 'https://explorer.energyweb.org',
+  SENTRY_DNS:'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,5 +2,6 @@ export const environment = {
   production: true,
   API_URL: 'https://api.drecs.org/api/',
   Explorer_URL: 'https://explorer.energyweb.org',
-  SENTRY_DNS:'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
+  SENTRY_DNS:
+    'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,4 +5,5 @@ export const environment = {
   Explorer_URL: 'https://explorer.energyweb.org',
   SENTRY_DNS:
     'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
+  SENTRY_ENV: 'production',
 };

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -9,6 +9,7 @@ export const environment = {
   Explorer_URL: 'https://volta-explorer.energyweb.org',
   SENTRY_DNS:
     'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
+  SENTRY_ENV: 'stagging',
 };
 
 /*

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -6,7 +6,8 @@ export const environment = {
   production: false,
   API_URL: 'https://stage-api.drecs.org/api/',
   Explorer_URL: 'https://volta-explorer.energyweb.org',
-  SENTRY_DNS:'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
+  SENTRY_DNS:
+    'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
 };
 
 /*

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -6,6 +6,7 @@ export const environment = {
   production: false,
   API_URL: 'https://stage-api.drecs.org/api/',
   Explorer_URL: 'https://volta-explorer.energyweb.org',
+  SENTRY_DNS:'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
 };
 
 /*

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -4,6 +4,7 @@
 
 export const environment = {
   production: false,
+  staging: true,
   API_URL: 'https://stage-api.drecs.org/api/',
   Explorer_URL: 'https://volta-explorer.energyweb.org',
   SENTRY_DNS:

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,6 +9,7 @@ export const environment = {
   Explorer_URL: 'https://volta-explorer.energyweb.org',
   SENTRY_DNS:
     'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
+  SENTRY_ENV: 'development',
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,9 +4,10 @@
 
 export const environment = {
   production: false,
+  staging: false,
   API_URL: 'http://localhost:3040/api/',
   Explorer_URL: 'https://volta-explorer.energyweb.org',
-  SENTRY_DNS: '',
+  SENTRY_DNS: 'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,7 +6,7 @@ export const environment = {
   production: false,
   API_URL: 'http://localhost:3040/api/',
   Explorer_URL: 'https://volta-explorer.energyweb.org',
-  SENTRY_DNS:'',
+  SENTRY_DNS: '',
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,7 +7,8 @@ export const environment = {
   staging: false,
   API_URL: 'http://localhost:3040/api/',
   Explorer_URL: 'https://volta-explorer.energyweb.org',
-  SENTRY_DNS: 'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
+  SENTRY_DNS:
+    'https://5447c8011f4b40f4dcb8742dfbaa1c0e@o4508380579430400.ingest.de.sentry.io/4508380582576208',
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,6 +6,7 @@ export const environment = {
   production: false,
   API_URL: 'http://localhost:3040/api/',
   Explorer_URL: 'https://volta-explorer.energyweb.org',
+  SENTRY_DNS:'',
 };
 
 /*

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,11 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
 import { environment } from './environments/environment';
 import { AppModule } from './app/app.module';
+import { appConfig } from './app/app.config';
 if (environment.production) {
   enableProdMode();
 }
 
 platformBrowserDynamic()
-  .bootstrapModule(AppModule)
+  .bootstrapModule(AppModule,appConfig)
   .catch((err) => console.error(err));

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,5 +8,5 @@ if (environment.production) {
 }
 
 platformBrowserDynamic()
-  .bootstrapModule(AppModule,appConfig)
+  .bootstrapModule(AppModule, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
### Integrated Sentry For error monitoring on the frontend

We wanted to monitor errors in production, stage, and dev and be able to spot them in time  to achieve that I did the following:

- Sentry is setup and configured to the DREC frontend account
- Sentry logs all the errors and warnings happening in the frontend
- We log errors based on the environment production, stage, and dev
- Sentry shouldn't be log errors happening in local development

### Issue ticket #205 and [link](https://github.com/orgs/d-rec/projects/2/views/8?pane=issue&itemId=89101606&issue=d-rec%7Cdrec-ui%7C205)
### HOW THIS SHOULD BE TESTED IN DEVELOPMENT MODE

- Add SENTRY_DNS variable in environment.ts
- Change the environment in app.config.ts to development
- you can add a button on the landing page with a function to throw an error 
- Refresh the sentry dashboard

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] No existing features have been broken without good reason.
- [x] The code style guideline have been followed
- [x] Documentation has been updated to reflect your changes.
