### PR TITLE
OC checklist: search box that highlights matches across items and cross-check hints

### DIFF
--- a/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.html
+++ b/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.html
@@ -28,11 +28,30 @@
       >Clear</button>
     </div>
 
+    <div class="ocp__search">
+      <input
+        type="search"
+        class="ocp__search-input"
+        placeholder="Search item or cross-check (e.g. RMS)…"
+        [value]="filter"
+        (input)="onFilterInput($event)"
+      />
+      <button
+        type="button"
+        class="ocp__search-clear"
+        *ngIf="filter"
+        (click)="clearFilter()"
+        title="Clear search"
+      >×</button>
+      <span class="ocp__search-count" *ngIf="filter">{{ matchCount() }} match{{ matchCount() === 1 ? '' : 'es' }}</span>
+    </div>
+
     <ul class="ocp__list">
       <ng-container *ngFor="let r of visibleRows; trackBy: trackRow">
         <li
           class="ocp__row"
           [class.ocp__row--checked]="isRowComplete(r)"
+          [class.ocp__row--match]="isMatch(r)"
         >
           <label
             class="ocp__label"
@@ -47,16 +66,23 @@
               (change)="toggleRow(r.n.toString())"
             />
             <span class="ocp__num">{{ r.n }}</span>
-            <span
-              class="ocp__item"
-              [class.ocp__item--hinted]="r.compare"
-            >{{ r.item }}</span>
+            <span class="ocp__item-wrap">
+              <span
+                class="ocp__item"
+                [class.ocp__item--hinted]="r.compare"
+              >{{ r.item }}</span>
+              <span
+                *ngIf="filter && r.compare && isMatch(r)"
+                class="ocp__compare-inline"
+              >{{ r.compare }}</span>
+            </span>
           </label>
         </li>
         <li
           *ngFor="let s of r.subItems; let i = index; trackBy: trackSub"
           class="ocp__row ocp__row--sub"
           [class.ocp__row--checked]="checked.has(r.n + '.' + i)"
+          [class.ocp__row--match]="isSubMatch(s)"
         >
           <label class="ocp__label ocp__label--sub">
             <input

--- a/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.html
+++ b/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.html
@@ -6,7 +6,9 @@
     [matTooltip]="collapsed ? 'Show registration checklist' : 'Hide checklist'"
     matTooltipPosition="left"
   >
-    <span class="ocp__tab-label" aria-hidden="true">{{ collapsed ? '‹' : '›' }}</span>
+    <span class="ocp__tab-label" aria-hidden="true">{{
+      collapsed ? '‹' : '›'
+    }}</span>
   </button>
 
   <div class="ocp__panel" *ngIf="!collapsed">
@@ -17,15 +19,23 @@
         type="button"
         class="ocp__clear"
         (click)="toggleHideNoCrosscheck()"
-        [title]="hideNoCrosscheck ? 'Show all items' : 'Hide items without cross-checks'"
-      >{{ hideNoCrosscheck ? 'Show all' : 'Hide n/a' }}</button>
+        [title]="
+          hideNoCrosscheck
+            ? 'Show all items'
+            : 'Hide items without cross-checks'
+        "
+      >
+        {{ hideNoCrosscheck ? 'Show all' : 'Hide n/a' }}
+      </button>
       <button
         type="button"
         class="ocp__clear"
         (click)="clearAll()"
         [disabled]="checked.size === 0"
         title="Uncheck all"
-      >Clear</button>
+      >
+        Clear
+      </button>
     </div>
 
     <div class="ocp__search">
@@ -42,8 +52,12 @@
         *ngIf="filter"
         (click)="clearFilter()"
         title="Clear search"
-      >×</button>
-      <span class="ocp__search-count" *ngIf="filter">{{ matchCount() }} match{{ matchCount() === 1 ? '' : 'es' }}</span>
+      >
+        ×
+      </button>
+      <span class="ocp__search-count" *ngIf="filter"
+        >{{ matchCount() }} match{{ matchCount() === 1 ? '' : 'es' }}</span
+      >
     </div>
 
     <ul class="ocp__list">
@@ -67,14 +81,14 @@
             />
             <span class="ocp__num">{{ r.n }}</span>
             <span class="ocp__item-wrap">
-              <span
-                class="ocp__item"
-                [class.ocp__item--hinted]="r.compare"
-              >{{ r.item }}</span>
+              <span class="ocp__item" [class.ocp__item--hinted]="r.compare">{{
+                r.item
+              }}</span>
               <span
                 *ngIf="filter && r.compare && isMatch(r)"
                 class="ocp__compare-inline"
-              >{{ r.compare }}</span>
+                >{{ r.compare }}</span
+              >
             </span>
           </label>
         </li>

--- a/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.scss
+++ b/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.scss
@@ -207,7 +207,6 @@
 
   &--hinted {
     border-bottom: 1px dotted #94a3b8;
-    cursor: help;
   }
 }
 

--- a/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.scss
+++ b/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.scss
@@ -96,6 +96,59 @@
   }
 }
 
+.ocp__search {
+  position: relative;
+  padding: 6px 10px;
+  border-bottom: 1px solid #e2e8f0;
+  background: #f8fafc;
+  flex-shrink: 0;
+}
+
+.ocp__search-input {
+  width: 100%;
+  font-size: 11px;
+  padding: 4px 22px 4px 8px;
+  border: 1px solid #cbd5e1;
+  border-radius: 4px;
+  background: #fff;
+  color: #1e293b;
+  outline: none;
+
+  &:focus {
+    border-color: #0f766e;
+    box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.15);
+  }
+
+  &::placeholder {
+    color: #94a3b8;
+  }
+}
+
+.ocp__search-clear {
+  position: absolute;
+  right: 14px;
+  top: calc(50% - 2px);
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  font-size: 14px;
+  line-height: 1;
+  color: #64748b;
+  cursor: pointer;
+  padding: 2px 4px;
+
+  &:hover {
+    color: #1e293b;
+  }
+}
+
+.ocp__search-count {
+  display: block;
+  font-size: 10px;
+  color: #64748b;
+  margin-top: 4px;
+}
+
 .ocp__list {
   list-style: none;
   margin: 0;
@@ -199,6 +252,34 @@
     font-size: 11.5px;
     color: #475569;
   }
+}
+
+.ocp__row--match {
+  background: #fef9c3;
+
+  .ocp__label:hover {
+    background: #fde68a;
+  }
+
+  &.ocp__row--checked {
+    background: linear-gradient(90deg, #ecfdf5 0%, #fef9c3 40%);
+  }
+}
+
+.ocp__item-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.ocp__compare-inline {
+  font-size: 10.5px;
+  color: #64748b;
+  font-style: italic;
+  word-break: break-word;
+  line-height: 1.3;
 }
 
 .ocp__sub-bullet {

--- a/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.ts
+++ b/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.ts
@@ -237,6 +237,8 @@ export class OcChecklistPanelComponent
   checked = new Set<string>();
   /** When true, hide rows that have neither a cross-check nor sub-items. */
   hideNoCrosscheck = this.loadHidePref();
+  /** Free-text filter matching item name, cross-check hint, and sub-item labels. */
+  filter = '';
   private static readonly HIDE_PREF_KEY = 'oc-checklist:hide-no-crosscheck';
 
   constructor(
@@ -291,6 +293,41 @@ export class OcChecklistPanelComponent
     return this.rows.filter(
       (r) => r.compare || (r.subItems && r.subItems.length > 0),
     );
+  }
+
+  private get filterQuery(): string {
+    return this.filter.trim().toLowerCase();
+  }
+
+  isMatch(r: OcRow): boolean {
+    const q = this.filterQuery;
+    if (!q) return false;
+    return (
+      r.item.toLowerCase().includes(q) ||
+      r.compare.toLowerCase().includes(q) ||
+      (r.subItems?.some((s) => s.toLowerCase().includes(q)) ?? false)
+    );
+  }
+
+  isSubMatch(s: string): boolean {
+    const q = this.filterQuery;
+    return !!q && s.toLowerCase().includes(q);
+  }
+
+  matchCount(): number {
+    const q = this.filterQuery;
+    if (!q) return 0;
+    return this.visibleRows.filter((r) => this.isMatch(r)).length;
+  }
+
+  onFilterInput(ev: Event): void {
+    this.filter = (ev.target as HTMLInputElement).value;
+    this.cdr.markForCheck();
+  }
+
+  clearFilter(): void {
+    this.filter = '';
+    this.cdr.markForCheck();
   }
 
   toggleHideNoCrosscheck(): void {


### PR DESCRIPTION
The OC checklist panel surfaces the "cross-check with: X, Y, Z" hint text only via \`matTooltip\`, so a reviewer doing Ctrl+F for "RMS" (etc.) gets zero hits, even though four OC# rows reference it in their hints.

Added an in-panel search input that matches against:
- the item name
- the \`compare\` hint string
- any sub-item labels

Behavior: rows are **highlighted in place** (yellow background), not filtered out — so you keep context. When a match comes from the hint rather than the item name, the hint text is surfaced inline under the item so the reviewer can see *why* it matched without having to hover. Header shows a live match count.

Also: dropped the \`cursor: help\` on hinted items. The dotted underline already signals a tooltip is available; the \`?\` cursor was redundant visual noise.

## Notes for reviewers

- Component is standalone; no \`FormsModule\` added — uses \`[value]\` + \`(input)\` event binding to stay lean.
- Search state is in-memory only, not persisted. That's intentional: it's a query, not a preference.