### PR TITLE
Metering evidence: tesseract OCR button + tabulated file lists across all three surfaces

### DIFF
--- a/src/app/utils/file-ext.ts
+++ b/src/app/utils/file-ext.ts
@@ -1,0 +1,28 @@
+/**
+ * Extract a file extension (lowercased) from a URL or filename.
+ *
+ * Returns `''` when the input has no dot-suffix, when the suffix is longer
+ * than 6 chars (not a real extension — probably the tail end of a path with
+ * a dot in it), or when it contains anything outside `[a-z0-9]`.
+ *
+ * Implemented without a regex to avoid SonarCloud's super-linear-backtracking
+ * false positive on `/\.([a-z0-9]{1,6})$/i`. The bounded repetition was safe,
+ * but this is simpler and skips the argument.
+ */
+export function extractExt(source: string | null | undefined): string {
+  if (!source) return '';
+  const qIdx = source.indexOf('?');
+  const path = qIdx === -1 ? source : source.slice(0, qIdx);
+  const lastDot = path.lastIndexOf('.');
+  if (lastDot < 0 || lastDot === path.length - 1) return '';
+  const ext = path.slice(lastDot + 1);
+  if (ext.length < 1 || ext.length > 6) return '';
+  for (let i = 0; i < ext.length; i++) {
+    const c = ext.charCodeAt(i);
+    const isDigit = c >= 48 && c <= 57; //  0-9
+    const isLower = c >= 97 && c <= 122; // a-z
+    const isUpper = c >= 65 && c <= 90; //  A-Z
+    if (!isDigit && !isLower && !isUpper) return '';
+  }
+  return ext.toLowerCase();
+}

--- a/src/app/view/device-reviews/device-info-window/device-info-window.component.html
+++ b/src/app/view/device-reviews/device-info-window/device-info-window.component.html
@@ -24,7 +24,9 @@
           class="di__search-clear"
           (click)="search = ''"
           title="Clear"
-        >&times;</button>
+        >
+          &times;
+        </button>
       </div>
 
       <div class="di__body">
@@ -36,19 +38,31 @@
           >
             <h3 *ngIf="section.heading" class="di__heading">
               {{ section.heading }}
-              <span *ngIf="section.heading === 'Documents'" style="font-weight:400;color:#64748b;font-size:12px;">
-                ({{ documents.length }} file{{ documents.length === 1 ? '' : 's' }} loaded)
+              <span
+                *ngIf="section.heading === 'Documents'"
+                style="font-weight: 400; color: #64748b; font-size: 12px"
+              >
+                ({{ documents.length }} file{{
+                  documents.length === 1 ? '' : 's'
+                }}
+                loaded)
               </span>
             </h3>
             <ng-container *ngFor="let f of section.fields; trackBy: trackField">
-              <ng-container *ngIf="f.tabular && f.links && f.links.length; else nonTabular">
+              <ng-container
+                *ngIf="f.tabular && f.links && f.links.length; else nonTabular"
+              >
                 <div
                   class="di__field"
                   [attr.title]="f.hint || null"
                   [class.di__field--hinted]="f.hint"
                 >
                   <b [innerHTML]="f.label | highlight: search"></b>
-                  <span class="di__me-count"> ({{ f.links.length }} file{{ f.links.length === 1 ? '' : 's' }})</span>
+                  <span class="di__me-count">
+                    ({{ f.links.length }} file{{
+                      f.links.length === 1 ? '' : 's'
+                    }})</span
+                  >
                 </div>
                 <div class="di__me-table">
                   <div class="di__me-row di__me-row--header">
@@ -56,7 +70,10 @@
                     <span class="di__me-name">Filename</span>
                     <span class="di__me-type">Type</span>
                   </div>
-                  <div class="di__me-row" *ngFor="let l of f.links; let i = index">
+                  <div
+                    class="di__me-row"
+                    *ngFor="let l of f.links; let i = index; trackBy: trackLink"
+                  >
                     <span class="di__me-idx">{{ i + 1 }}</span>
                     <a
                       class="di__me-name"
@@ -76,13 +93,24 @@
                   [class.di__field--hinted]="f.hint"
                 >
                   <b [innerHTML]="f.label | highlight: search"></b>:
-                  <ng-container *ngIf="f.links && f.links.length; else maybeItems">
+                  <ng-container
+                    *ngIf="f.links && f.links.length; else maybeItems"
+                  >
                     <ng-container *ngFor="let l of f.links; let last = last">
-                      <a href="javascript:void(0)" (click)="openLink(l.url, $event)" (mousedown)="openLink(l.url, $event)" [innerHTML]="l.text | highlight: search"></a><span *ngIf="!last">, </span>
+                      <a
+                        href="javascript:void(0)"
+                        (click)="openLink(l.url, $event)"
+                        (mousedown)="openLink(l.url, $event)"
+                        [innerHTML]="l.text | highlight: search"
+                      ></a
+                      ><span *ngIf="!last">, </span>
                     </ng-container>
                   </ng-container>
                   <ng-template #maybeItems>
-                    <span *ngIf="!f.items || f.items.length === 0" [innerHTML]="(f.value || '—') | highlight: search"></span>
+                    <span
+                      *ngIf="!f.items || f.items.length === 0"
+                      [innerHTML]="f.value || '—' | highlight: search"
+                    ></span>
                   </ng-template>
                 </p>
                 <p
@@ -90,7 +118,9 @@
                   class="di__field di__field--sub"
                 >
                   <span class="di__sub-bullet">↳</span>
-                  <span [innerHTML]="(i + 1) + '. ' + it | highlight: search"></span>
+                  <span
+                    [innerHTML]="i + 1 + '. ' + it | highlight: search"
+                  ></span>
                 </p>
               </ng-template>
             </ng-container>
@@ -132,13 +162,18 @@
               </svg>
             </div>
           </ng-container>
-
         </ng-container>
       </div>
 
       <div class="di__footer">
-        <button type="button" class="di__btn" (click)="copyVisible()">Copy</button>
-        <button type="button" class="di__btn di__btn--primary" (click)="close()">
+        <button type="button" class="di__btn" (click)="copyVisible()">
+          Copy
+        </button>
+        <button
+          type="button"
+          class="di__btn di__btn--primary"
+          (click)="close()"
+        >
           Close
         </button>
       </div>

--- a/src/app/view/device-reviews/device-info-window/device-info-window.component.html
+++ b/src/app/view/device-reviews/device-info-window/device-info-window.component.html
@@ -41,28 +41,58 @@
               </span>
             </h3>
             <ng-container *ngFor="let f of section.fields; trackBy: trackField">
-              <p
-                class="di__field"
-                [attr.title]="f.hint || null"
-                [class.di__field--hinted]="f.hint"
-              >
-                <b [innerHTML]="f.label | highlight: search"></b>:
-                <ng-container *ngIf="f.links && f.links.length; else maybeItems">
-                  <ng-container *ngFor="let l of f.links; let last = last">
-                    <a href="javascript:void(0)" (click)="openLink(l.url, $event)" (mousedown)="openLink(l.url, $event)" [innerHTML]="l.text | highlight: search"></a><span *ngIf="!last">, </span>
+              <ng-container *ngIf="f.tabular && f.links && f.links.length; else nonTabular">
+                <div
+                  class="di__field"
+                  [attr.title]="f.hint || null"
+                  [class.di__field--hinted]="f.hint"
+                >
+                  <b [innerHTML]="f.label | highlight: search"></b>
+                  <span class="di__me-count"> ({{ f.links.length }} file{{ f.links.length === 1 ? '' : 's' }})</span>
+                </div>
+                <div class="di__me-table">
+                  <div class="di__me-row di__me-row--header">
+                    <span class="di__me-idx">#</span>
+                    <span class="di__me-name">Filename</span>
+                    <span class="di__me-type">Type</span>
+                  </div>
+                  <div class="di__me-row" *ngFor="let l of f.links; let i = index">
+                    <span class="di__me-idx">{{ i + 1 }}</span>
+                    <a
+                      class="di__me-name"
+                      href="javascript:void(0)"
+                      (click)="openLink(l.url, $event)"
+                      (mousedown)="openLink(l.url, $event)"
+                      [innerHTML]="l.text | highlight: search"
+                    ></a>
+                    <span class="di__me-type">{{ linkExt(l) || '—' }}</span>
+                  </div>
+                </div>
+              </ng-container>
+              <ng-template #nonTabular>
+                <p
+                  class="di__field"
+                  [attr.title]="f.hint || null"
+                  [class.di__field--hinted]="f.hint"
+                >
+                  <b [innerHTML]="f.label | highlight: search"></b>:
+                  <ng-container *ngIf="f.links && f.links.length; else maybeItems">
+                    <ng-container *ngFor="let l of f.links; let last = last">
+                      <a href="javascript:void(0)" (click)="openLink(l.url, $event)" (mousedown)="openLink(l.url, $event)" [innerHTML]="l.text | highlight: search"></a><span *ngIf="!last">, </span>
+                    </ng-container>
                   </ng-container>
-                </ng-container>
-                <ng-template #maybeItems>
-                  <span *ngIf="!f.items || f.items.length === 0" [innerHTML]="(f.value || '—') | highlight: search"></span>
-                </ng-template>
-              </p>
-              <p
-                *ngFor="let it of f.items; let i = index"
-                class="di__field di__field--sub"
-              >
-                <span class="di__sub-bullet">↳</span>
-                <span [innerHTML]="(i + 1) + '. ' + it | highlight: search"></span>
-              </p>
+                  <ng-template #maybeItems>
+                    <span *ngIf="!f.items || f.items.length === 0" [innerHTML]="(f.value || '—') | highlight: search"></span>
+                  </ng-template>
+                </p>
+                <p
+                  *ngFor="let it of f.items; let i = index"
+                  class="di__field di__field--sub"
+                >
+                  <span class="di__sub-bullet">↳</span>
+                  <span [innerHTML]="(i + 1) + '. ' + it | highlight: search"></span>
+                </p>
+              </ng-template>
             </ng-container>
 
             <div

--- a/src/app/view/device-reviews/device-info-window/device-info-window.component.scss
+++ b/src/app/view/device-reviews/device-info-window/device-info-window.component.scss
@@ -177,3 +177,68 @@
     }
   }
 }
+
+// ── Metering-evidence tabular list ────────────────────────────────────────────
+.di__me-count {
+  color: #64748b;
+  font-weight: 400;
+}
+
+.di__me-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 4px 0 8px;
+  font-size: 12px;
+}
+
+.di__me-row {
+  display: grid;
+  grid-template-columns: 28px 1fr 52px;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-bottom: 1px solid #f1f5f9;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &--header {
+    background: #f8fafc;
+    font-weight: 700;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #64748b;
+  }
+}
+
+.di__me-idx {
+  text-align: right;
+  color: #64748b;
+  font-variant-numeric: tabular-nums;
+}
+
+.di__me-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #2563eb;
+
+  &[href] {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}
+
+.di__me-type {
+  text-align: right;
+  color: #64748b;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/src/app/view/device-reviews/device-info-window/device-info-window.component.ts
+++ b/src/app/view/device-reviews/device-info-window/device-info-window.component.ts
@@ -476,6 +476,7 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
 
   trackSection = (_: number, s: Section) => s.heading;
   trackField = (_: number, f: Field) => f.label;
+  trackLink = (_: number, l: { url: string }) => l.url;
 
   linkExt(l: { url: string; text: string }): string {
     return extractExt(l.text || l.url || '');

--- a/src/app/view/device-reviews/device-info-window/device-info-window.component.ts
+++ b/src/app/view/device-reviews/device-info-window/device-info-window.component.ts
@@ -28,6 +28,8 @@ interface Field {
   links?: { url: string; text: string }[];
   /** when present, render as indented sub-rows below the label */
   items?: string[];
+  /** when true AND links is populated, render as a #/Filename/Type table */
+  tabular?: boolean;
 }
 
 interface Section {
@@ -419,6 +421,7 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
             label: '(49) Metering Evidence',
             value: fmtDocs('METERING_EVIDENCE'),
             links: linksFor('METERING_EVIDENCE'),
+            tabular: true,
             hint: 'Sample metering evidence relied on for I-REC issuance',
           },
           {
@@ -472,4 +475,11 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
 
   trackSection = (_: number, s: Section) => s.heading;
   trackField = (_: number, f: Field) => f.label;
+
+  linkExt(l: { url: string; text: string }): string {
+    const src = l.text || l.url || '';
+    const path = src.split('?')[0];
+    const m = path.match(/\.([a-z0-9]{1,6})$/i);
+    return m ? m[1].toLowerCase() : '';
+  }
 }

--- a/src/app/view/device-reviews/device-info-window/device-info-window.component.ts
+++ b/src/app/view/device-reviews/device-info-window/device-info-window.component.ts
@@ -16,6 +16,7 @@ import { AssetService } from '../asset.service';
 import { satellitePreview, SatellitePreview } from '../../map/map.component';
 import { environment } from '../../../../environments/environment';
 import { CountryNamePipe } from '../country-name.pipe';
+import { extractExt } from '../../../utils/file-ext';
 
 interface Field {
   label: string;
@@ -477,9 +478,6 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
   trackField = (_: number, f: Field) => f.label;
 
   linkExt(l: { url: string; text: string }): string {
-    const src = l.text || l.url || '';
-    const path = src.split('?')[0];
-    const m = path.match(/\.([a-z0-9]{1,6})$/i);
-    return m ? m[1].toLowerCase() : '';
+    return extractExt(l.text || l.url || '');
   }
 }

--- a/src/app/view/device-reviews/documents-window/documents-window.component.html
+++ b/src/app/view/device-reviews/documents-window/documents-window.component.html
@@ -194,18 +194,28 @@
             <span *ngIf="item.meteringEvidenceUrls.length" class="section-count">({{ item.meteringEvidenceUrls.length }})</span>
           </div>
           <ng-container *ngIf="isSectionOpen(item.id, 'meteringEvidence')">
+            <div *ngIf="item.meteringEvidenceUrls.length" class="dr-row dr-row--me-header">
+              <span class="me-col-check"></span>
+              <span class="me-col-idx">#</span>
+              <span class="me-col-name">Filename</span>
+              <span class="me-col-type">Type</span>
+            </div>
             <div
               *ngFor="let url of item.meteringEvidenceUrls; let i = index; trackBy: trackByIndex"
-              class="dr-row dr-row--file"
+              class="dr-row dr-row--file dr-row--me-file"
               (dblclick)="openFile(url, $event, false, true)"
               (keydown.enter)="openFile(url, $event, false, true)"
             >
-              <span class="review-check" role="checkbox" tabindex="0" [attr.aria-checked]="!!reviewed[item.id + ':me:' + i]" [class.review-check--done]="reviewed[item.id + ':me:' + i]" (click)="toggleReviewed(item.id + ':me:' + i, $event)" (keydown.enter)="toggleReviewed(item.id + ':me:' + i, $event)" title="Mark as reviewed">
+              <span class="review-check me-col-check" role="checkbox" tabindex="0" [attr.aria-checked]="!!reviewed[item.id + ':me:' + i]" [class.review-check--done]="reviewed[item.id + ':me:' + i]" (click)="toggleReviewed(item.id + ':me:' + i, $event)" (keydown.enter)="toggleReviewed(item.id + ':me:' + i, $event)" title="Mark as reviewed">
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="2"/><path *ngIf="reviewed[item.id + ':me:' + i]" d="M6 12l4 4 8-8" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
               </span>
-              <svg class="file-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM6 20V4h5v7h7v9H6z" fill="#64748b"/></svg>
-              <span class="file-name" [innerHTML]="hl(fileDisplayName(item, 'me:' + i, url), result.searchTerm)"></span>
-              <span *ngIf="isBroken(url)" class="missing-tag">(missing)</span>
+              <span class="me-col-idx">{{ i + 1 }}</span>
+              <span class="me-col-name">
+                <svg class="file-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM6 20V4h5v7h7v9H6z" fill="#64748b"/></svg>
+                <span class="file-name" [innerHTML]="hl(fileDisplayName(item, 'me:' + i, url), result.searchTerm)"></span>
+                <span *ngIf="isBroken(url)" class="missing-tag">(missing)</span>
+              </span>
+              <span class="me-col-type">{{ fileExt(url) || '—' }}</span>
             </div>
             <div *ngIf="!item.meteringEvidenceUrls.length" class="dr-row dr-row--empty"><span class="missing-tag">missing</span></div>
           </ng-container>

--- a/src/app/view/device-reviews/documents-window/documents-window.component.html
+++ b/src/app/view/device-reviews/documents-window/documents-window.component.html
@@ -197,8 +197,8 @@
             <div
               *ngFor="let url of item.meteringEvidenceUrls; let i = index; trackBy: trackByIndex"
               class="dr-row dr-row--file"
-              (dblclick)="openFile(url, $event)"
-              (keydown.enter)="openFile(url, $event)"
+              (dblclick)="openFile(url, $event, false, true)"
+              (keydown.enter)="openFile(url, $event, false, true)"
             >
               <span class="review-check" role="checkbox" tabindex="0" [attr.aria-checked]="!!reviewed[item.id + ':me:' + i]" [class.review-check--done]="reviewed[item.id + ':me:' + i]" (click)="toggleReviewed(item.id + ':me:' + i, $event)" (keydown.enter)="toggleReviewed(item.id + ':me:' + i, $event)" title="Mark as reviewed">
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="2"/><path *ngIf="reviewed[item.id + ':me:' + i]" d="M6 12l4 4 8-8" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/src/app/view/device-reviews/documents-window/documents-window.component.scss
+++ b/src/app/view/device-reviews/documents-window/documents-window.component.scss
@@ -446,6 +446,30 @@ $legacy:   #a0845c;
 .section-count { font-size: 11px; color: $muted; font-weight: 400; text-transform: none; letter-spacing: 0; }
 .dr-row--section .add-btn { margin-left: auto; }
 
+// ── Metering-evidence tabular layout ──────────────────────────────────────────
+.dr-row--me-header {
+  padding-left: 48px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: $muted;
+  background: #f8fafc;
+  border-bottom: 1px solid $border;
+  cursor: default;
+  &:hover { background: #f8fafc; }
+}
+
+.dr-row--me-file {
+  // lock row layout to align with header
+  padding-left: 48px;
+}
+
+.me-col-check { width: 18px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; }
+.me-col-idx   { width: 24px; flex-shrink: 0; text-align: right; color: $muted; font-variant-numeric: tabular-nums; }
+.me-col-name  { flex: 1; min-width: 0; display: flex; align-items: center; gap: 6px; overflow: hidden; .file-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; } }
+.me-col-type  { width: 54px; flex-shrink: 0; text-align: right; color: $muted; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+
 .review-check {
   display: inline-flex;
   align-items: center;

--- a/src/app/view/device-reviews/documents-window/documents-window.component.ts
+++ b/src/app/view/device-reviews/documents-window/documents-window.component.ts
@@ -1078,6 +1078,12 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     return this.fileName(url);
   }
 
+  fileExt(url: string): string {
+    const path = (url || '').split('?')[0];
+    const m = path.match(/\.([a-z0-9]{1,6})$/i);
+    return m ? m[1].toLowerCase() : '';
+  }
+
   fileName(url: string): string {
     try {
       const withoutQuery = url.split('?')[0];

--- a/src/app/view/device-reviews/documents-window/documents-window.component.ts
+++ b/src/app/view/device-reviews/documents-window/documents-window.component.ts
@@ -26,6 +26,7 @@ import {
   getHint,
 } from '../../../utils/evidence-requirements';
 import { environment } from '../../../../environments/environment';
+import { extractExt } from '../../../utils/file-ext';
 
 @Component({
   standalone: false,
@@ -1079,9 +1080,7 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   }
 
   fileExt(url: string): string {
-    const path = (url || '').split('?')[0];
-    const m = path.match(/\.([a-z0-9]{1,6})$/i);
-    return m ? m[1].toLowerCase() : '';
+    return extractExt(url);
   }
 
   fileName(url: string): string {

--- a/src/app/view/device-reviews/picture-window/picture-window.component.html
+++ b/src/app/view/device-reviews/picture-window/picture-window.component.html
@@ -7,6 +7,15 @@
   (close)="close()"
 >
     <div class="picw">
+      <div *ngIf="enableOcr" class="picw__toolbar">
+        <button
+          type="button"
+          class="picw__ocr-btn"
+          (click)="runOcr()"
+          (mousedown)="runOcr()"
+          [disabled]="ocrRunning"
+        >{{ ocrRunning ? 'Extracting… ' + ocrProgress + '%' : (ocrText ? 'Re-run OCR' : 'Extract Text (OCR)') }}</button>
+      </div>
       <!-- Panel detection is reserved for the live satellite view; regular
            uploaded pictures show the image only (zoom/pan). -->
       <div class="picw__image-area">

--- a/src/app/view/device/device-details/device-details.component.html
+++ b/src/app/view/device/device-details/device-details.component.html
@@ -319,7 +319,11 @@
               </div>
               <div
                 class="me-row"
-                *ngFor="let d of docsOf(row.type); let i = index"
+                *ngFor="
+                  let d of docsOf(row.type);
+                  let i = index;
+                  trackBy: trackDocById
+                "
               >
                 <span class="me-col-idx">{{ i + 1 }}</span>
                 <span class="me-col-name"

--- a/src/app/view/device/device-details/device-details.component.html
+++ b/src/app/view/device/device-details/device-details.component.html
@@ -291,10 +291,10 @@
             ]
           "
         >
-          <p>
+          <p *ngIf="row.type !== 'METERING_EVIDENCE'">
             <b>{{ row.label }} {{ row.oc }}</b
             >:
-            <ng-container *ngIf="docsOf(row.type).length; else noDocs">
+            <ng-container *ngIf="docsOf(row.type).length; else noDocsInline">
               <ng-container *ngFor="let d of docsOf(row.type); let last = last">
                 <a href="#" (click)="openDocLink(d.id, $event)">{{
                   docLinkLabel(d)
@@ -302,8 +302,38 @@
                 ><span *ngIf="!last">, </span>
               </ng-container>
             </ng-container>
-            <ng-template #noDocs>—</ng-template>
+            <ng-template #noDocsInline>—</ng-template>
           </p>
+          <div *ngIf="row.type === 'METERING_EVIDENCE'" class="me-block">
+            <p class="me-title">
+              <b>{{ row.label }} {{ row.oc }}</b>
+            </p>
+            <div
+              *ngIf="docsOf(row.type).length; else noDocsTable"
+              class="me-table"
+            >
+              <div class="me-row me-row--header">
+                <span class="me-col-idx">#</span>
+                <span class="me-col-name">Filename</span>
+                <span class="me-col-type">Type</span>
+              </div>
+              <div
+                class="me-row"
+                *ngFor="let d of docsOf(row.type); let i = index"
+              >
+                <span class="me-col-idx">{{ i + 1 }}</span>
+                <span class="me-col-name"
+                  ><a href="#" (click)="openDocLink(d.id, $event)">{{
+                    docLinkLabel(d)
+                  }}</a></span
+                >
+                <span class="me-col-type">{{
+                  fileExt(d.url) || fileExt(d.originalFilename || '') || '—'
+                }}</span>
+              </div>
+            </div>
+            <ng-template #noDocsTable><p>—</p></ng-template>
+          </div>
         </ng-container>
       </div>
     </ng-template>

--- a/src/app/view/device/device-details/device-details.component.scss
+++ b/src/app/view/device/device-details/device-details.component.scss
@@ -54,3 +54,69 @@
   display: flex;
   justify-content: center;
 }
+
+.me-block {
+  margin: 2px 0 6px;
+}
+
+.me-title {
+  margin: 2px 0 !important;
+}
+
+.me-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #e2e6ea;
+  border-radius: 4px;
+  overflow: hidden;
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+.me-row {
+  display: grid;
+  grid-template-columns: 32px 1fr 60px;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-bottom: 1px solid #f1f5f9;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &--header {
+    background: #f8fafc;
+    font-weight: 700;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #64748b;
+  }
+
+  a {
+    color: #2563eb;
+    text-decoration: underline;
+    word-break: break-all;
+  }
+}
+
+.me-col-idx {
+  text-align: right;
+  color: #64748b;
+  font-variant-numeric: tabular-nums;
+}
+
+.me-col-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.me-col-type {
+  text-align: right;
+  color: #64748b;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/src/app/view/device/device-details/device-details.component.ts
+++ b/src/app/view/device/device-details/device-details.component.ts
@@ -123,6 +123,13 @@ export class DeviceDetailsComponent {
     return d.label || d.originalFilename || `File ${d.id}`;
   }
 
+  fileExt(source: string | null | undefined): string {
+    if (!source) return '';
+    const path = source.split('?')[0];
+    const m = path.match(/\.([a-z0-9]{1,6})$/i);
+    return m ? m[1].toLowerCase() : '';
+  }
+
   splitSerials(joined: string | null | undefined): string[] {
     if (!joined) return [];
     return String(joined)

--- a/src/app/view/device/device-details/device-details.component.ts
+++ b/src/app/view/device/device-details/device-details.component.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../models';
 import { ToastrService } from 'ngx-toastr';
 import { satellitePreview, SatellitePreview } from '../../map/map.component';
+import { extractExt } from '../../../utils/file-ext';
 @Component({
   standalone: false,
   selector: 'app-device-details',
@@ -124,10 +125,7 @@ export class DeviceDetailsComponent {
   }
 
   fileExt(source: string | null | undefined): string {
-    if (!source) return '';
-    const path = source.split('?')[0];
-    const m = path.match(/\.([a-z0-9]{1,6})$/i);
-    return m ? m[1].toLowerCase() : '';
+    return extractExt(source);
   }
 
   splitSerials(joined: string | null | undefined): string[] {

--- a/src/app/view/device/device-details/device-details.component.ts
+++ b/src/app/view/device/device-details/device-details.component.ts
@@ -128,6 +128,8 @@ export class DeviceDetailsComponent {
     return extractExt(source);
   }
 
+  trackDocById = (_: number, d: { id: number }) => d.id;
+
   splitSerials(joined: string | null | undefined): string[] {
     if (!joined) return [];
     return String(joined)


### PR DESCRIPTION
Two related changes on the metering-evidence review surfaces.

## 1. OCR button on metering-evidence images

\`picture-window.component.ts\` already had an \`enableOcr\` input, a \`runOcr()\` method, and SCSS for \`__toolbar\` + \`__ocr-btn\` — but the template was missing the actual button. Wired it up, gated behind \`enableOcr\` so existing callers (site photos etc.) are unaffected.

Flipped \`enableOcr=true\` on the metering-evidence section's \`openFile\` calls so reviewers opening a meter screenshot get the OCR affordance. PDFs in the same section already have OCR via \`pdf-preview\`.

Button wired with both \`(click)\` and \`(mousedown)\` to work around the known \`app-ds-floating-window\` click-suppression behaviour.

## 2. Tabulated file lists

Metering-evidence file lists were rendered three different ways in three different components, all inline/comma-separated:

- \`documents-window\` (reviewer docs tree) — per-row but no column alignment
- \`device-details.component\` (Material dialog) — comma-separated
- \`device-info-window\` (floating device-details window) — comma-separated

Unified to a \`#\` / Filename / Type table on each surface. Only metering-evidence is tabulated; other doc types keep their existing inline rendering so the change stays scoped. The Type column is derived from the URL or original filename via a small \`fileExt()\` helper.