### PR TITLE
Capacity UI labels + sidemenu submenu indent

### DIFF
--- a/src/app/nav/sidemenu/sidemenu.component.scss
+++ b/src/app/nav/sidemenu/sidemenu.component.scss
@@ -48,7 +48,8 @@ $white: #fff;
   align-items: center;
   justify-content: center;
 
-  &:hover, &:active {
+  &:hover,
+  &:active {
     background-color: $color-muted;
     opacity: 0.5;
   }
@@ -166,7 +167,9 @@ mat-nav-list {
   }
 }
 
-::ng-deep .mat-expansion-panel-header.mat-expanded .mat-expansion-indicator::before {
+::ng-deep
+  .mat-expansion-panel-header.mat-expanded
+  .mat-expansion-indicator::before {
   transform: rotate(90deg);
 }
 

--- a/src/app/nav/sidemenu/sidemenu.component.scss
+++ b/src/app/nav/sidemenu/sidemenu.component.scss
@@ -120,7 +120,7 @@ mat-nav-list {
     letter-spacing: 0.3px;
     font-weight: 400;
     margin-bottom: 0;
-    padding: 2px 4px;
+    padding: 2px 4px 2px 24px;
 
     &.active {
       border-radius: 4px;

--- a/src/app/view/add-device-group/add-device-group.component.html
+++ b/src/app/view/add-device-group/add-device-group.component.html
@@ -55,7 +55,7 @@
           </div>
           <div class="col-md-3">
             <mat-form-field appearance="outline">
-              <mat-label>Target Capacity(MWh)</mat-label>
+              <mat-label>Target Volume (MWh)</mat-label>
 
               <input
                 matInput

--- a/src/app/view/add-device-group/add-device-group.component.html
+++ b/src/app/view/add-device-group/add-device-group.component.html
@@ -1,4 +1,4 @@
-<div class="body-bg add-device-group" >
+<div class="body-bg add-device-group">
   <mat-card>
     <mat-card-header
       class="d-flex justify-content-between mat-crd-hide align-items-center"
@@ -13,7 +13,9 @@
         <div class="example-container1 row">
           <div
             class="col-md-3"
-            *ngIf="loginuser.role === 'Admin' || loginuser.role === 'Registrant'"
+            *ngIf="
+              loginuser.role === 'Admin' || loginuser.role === 'Registrant'
+            "
           >
             <mat-form-field appearance="outline">
               <mat-label class="text-capitalize">Organization</mat-label>
@@ -153,7 +155,7 @@
                 [touchUi]="false"
                 [enableMeridian]="false"
                 [disableMinute]="false"
-                [hideTime]="false" 
+                [hideTime]="false"
               >
               </ngx-mat-datetime-picker>
             </mat-form-field>
@@ -378,30 +380,32 @@
               </div>
             </form>
 
-            <div
-              class="content text-center thead-width"
-              *ngIf="!loading"
-            >
+            <div class="content text-center thead-width" *ngIf="!loading">
               <table mat-table [dataSource]="dataSource" matSort>
                 <ng-container matColumnDef="select" sticky>
                   <th>
                     <mat-header-cell *matHeaderCellDef>
-                      <ng-container *ngIf="selectionType === 'checkbox'; else radioHeader">
+                      <ng-container
+                        *ngIf="selectionType === 'checkbox'; else radioHeader"
+                      >
                         <mat-checkbox
                           color="primary"
                           (change)="$event ? masterToggle() : null"
                           [checked]="selection.hasValue() && isAllSelected()"
-                          [indeterminate]="selection.hasValue() && !isAllSelected()"
+                          [indeterminate]="
+                            selection.hasValue() && !isAllSelected()
+                          "
                         >
                         </mat-checkbox>
                       </ng-container>
-                      <ng-template #radioHeader>
-                      </ng-template>
+                      <ng-template #radioHeader> </ng-template>
                     </mat-header-cell>
                   </th>
                   <td>
                     <mat-cell *cdkCellDef="let row">
-                      <ng-container *ngIf="selectionType === 'checkbox'; else radioCell">
+                      <ng-container
+                        *ngIf="selectionType === 'checkbox'; else radioCell"
+                      >
                         <mat-checkbox
                           color="primary"
                           (click)="$event.stopPropagation()"
@@ -450,7 +454,7 @@
                     Serial Number
                   </th>
                   <td mat-cell *matCellDef="let element">
-                    {{ element.serialNumber}}
+                    {{ element.serialNumber }}
                   </td>
                 </ng-container>
                 <ng-container
@@ -575,8 +579,11 @@
     <mat-card-footer>
       <div class="example-container mb-3 me-2 row">
         <div class="col-12 d-flex justify-content-end align-items-center gap-3">
-          <span *ngIf="selection.selected.length > 0" class="capacity-indicator"
-            [class.over-cap]="getSelectedCapacity() > 250">
+          <span
+            *ngIf="selection.selected.length > 0"
+            class="capacity-indicator"
+            [class.over-cap]="getSelectedCapacity() > 250"
+          >
             Selected: {{ selection.selected.length }} device(s),
             {{ getSelectedCapacity() }} / 250 kW
           </span>

--- a/src/app/view/device-groups/device-groups.component.html
+++ b/src/app/view/device-groups/device-groups.component.html
@@ -327,7 +327,7 @@
               mat-sort-header
               class="text-truncate"
             >
-              Aggregate Capacity
+              Aggregate Capacity (kW)
             </th>
             <td mat-cell *matCellDef="let row" class="table-data-device-groups">
               {{ row.aggregatedCapacity }}
@@ -548,9 +548,9 @@
             <div class="column col-4">
               <div class="row">
                 <p>
-                  <b> Target Capacity</b>:&nbsp;
+                  <b> Target Volume</b>:&nbsp;
                   <!--{{item.generationStartTime+'000'| date:'EEE d MMMM y hh:ss'}} - in UTC:-->
-                  {{ group_info.targetVolumeInMegaWattHour }}(Mwh)
+                  {{ group_info.targetVolumeInMegaWattHour }} MWh
                 </p>
               </div>
             </div>

--- a/src/app/view/device-groups/device-groups.component.html
+++ b/src/app/view/device-groups/device-groups.component.html
@@ -337,14 +337,33 @@
           <ng-container matColumnDef="groupReviewStatus">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Review</th>
             <td mat-cell *matCellDef="let row">
-              <span class="review-badge review-{{ row.groupReviewStatus || 'pending' }}">
+              <span
+                class="review-badge review-{{
+                  row.groupReviewStatus || 'pending'
+                }}"
+              >
                 {{ row.groupReviewStatus || 'pending' }}
               </span>
-              <span *ngIf="isAdmin() && row.groupReviewStatus === 'pending'" class="review-actions">
-                <button class="btn btn-sm btn-outline-success ms-1" (click)="updateReviewStatus(row.id, 'approved'); $event.stopPropagation()">
+              <span
+                *ngIf="isAdmin() && row.groupReviewStatus === 'pending'"
+                class="review-actions"
+              >
+                <button
+                  class="btn btn-sm btn-outline-success ms-1"
+                  (click)="
+                    updateReviewStatus(row.id, 'approved');
+                    $event.stopPropagation()
+                  "
+                >
                   <mat-icon class="small-icon">check</mat-icon>
                 </button>
-                <button class="btn btn-sm btn-outline-danger ms-1" (click)="updateReviewStatus(row.id, 'rejected'); $event.stopPropagation()">
+                <button
+                  class="btn btn-sm btn-outline-danger ms-1"
+                  (click)="
+                    updateReviewStatus(row.id, 'rejected');
+                    $event.stopPropagation()
+                  "
+                >
                   <mat-icon class="small-icon">close</mat-icon>
                 </button>
               </span>
@@ -628,9 +647,7 @@
             </td>
           </ng-container>
           <ng-container matColumnDef="siteName">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header>
-              Site Name
-            </th>
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Site Name</th>
             <td mat-cell *matCellDef="let row">{{ row.siteName }}</td>
           </ng-container>
           <ng-container matColumnDef="Name">

--- a/src/app/view/device/device-details/device-details.component.html
+++ b/src/app/view/device/device-details/device-details.component.html
@@ -42,7 +42,7 @@
         <h3 class="section-heading">Technical Details</h3>
         <p><b>Fuel Code</b>: {{ device_details.fuelname }}</p>
         <p><b>Device Type Code</b>: {{ device_details.devicetypename }}</p>
-        <p><b>Capacity ⁽⁹⁾</b>: {{ device_details.capacity }}</p>
+        <p><b>Capacity ⁽⁹⁾</b>: {{ device_details.capacity }} kW</p>
         <p><b>Commissioning Date ⁽¹⁰⁾</b>: {{ device_details.commissioningDate | date: 'dd MMM y hh:mm' }}</p>
         <p><b>OnBoarding Date</b>: {{ device_details.createdAt | date: 'dd MMM y hh:mm' }}</p>
         <p *ngIf="device_details.dataSource"><b>Data Source</b>: {{ device_details.dataSource }}</p>

--- a/src/app/view/device/device-details/device-details.component.html
+++ b/src/app/view/device/device-details/device-details.component.html
@@ -18,8 +18,7 @@
   <mat-dialog-content>
     <div *ngIf="loading; else content">
       <div class="spinner__loading">
-        <div>
-        </div>
+        <div></div>
       </div>
     </div>
     <ng-template #content>
@@ -28,107 +27,279 @@
         <p><b>Site Name ⁽¹⁾</b>: {{ device_details.siteName }}</p>
         <p *ngIf="device_details.serialNumber">
           <b>Meter or Measurement ID(s) ⁽¹⁴⁾</b>:
-          <span *ngFor="let s of splitSerials(device_details.serialNumber); let i = index; let last = last">
+          <span
+            *ngFor="
+              let s of splitSerials(device_details.serialNumber);
+              let i = index;
+              let last = last
+            "
+          >
             {{ i + 1 }}. {{ s }}<span *ngIf="!last">&nbsp;&middot;&nbsp;</span>
           </span>
         </p>
-        <p *ngIf="!device_details.serialNumber"><b>Meter or Measurement ID(s) ⁽¹⁴⁾</b>: —</p>
-        <p *ngIf="device_details.defaultAccountCode"><b>Default Account Code ⁽¹²⁾</b>: {{ device_details.defaultAccountCode }}</p>
-        <p *ngIf="device_details.requestedEffectiveRegDate"><b>Requested Effective Reg. Date ⁽¹¹⁾</b>: {{ device_details.requestedEffectiveRegDate }}</p>
-        <p *ngIf="device_details.registrationType"><b>Registration Type</b>: {{ device_details.registrationType }}</p>
-        <p *ngIf="device_details.volumeEvidenceType"><b>Volume Evidence Type</b>: {{ device_details.volumeEvidenceType }}</p>
-        <p *ngIf="device_details.verificationAgentName"><b>Verification Agent</b>: {{ device_details.verificationAgentName }}</p>
+        <p *ngIf="!device_details.serialNumber">
+          <b>Meter or Measurement ID(s) ⁽¹⁴⁾</b>: —
+        </p>
+        <p *ngIf="device_details.defaultAccountCode">
+          <b>Default Account Code ⁽¹²⁾</b>:
+          {{ device_details.defaultAccountCode }}
+        </p>
+        <p *ngIf="device_details.requestedEffectiveRegDate">
+          <b>Requested Effective Reg. Date ⁽¹¹⁾</b>:
+          {{ device_details.requestedEffectiveRegDate }}
+        </p>
+        <p *ngIf="device_details.registrationType">
+          <b>Registration Type</b>: {{ device_details.registrationType }}
+        </p>
+        <p *ngIf="device_details.volumeEvidenceType">
+          <b>Volume Evidence Type</b>: {{ device_details.volumeEvidenceType }}
+        </p>
+        <p *ngIf="device_details.verificationAgentName">
+          <b>Verification Agent</b>: {{ device_details.verificationAgentName }}
+        </p>
 
         <h3 class="section-heading">Technical Details</h3>
         <p><b>Fuel Code</b>: {{ device_details.fuelname }}</p>
         <p><b>Device Type Code</b>: {{ device_details.devicetypename }}</p>
         <p><b>Capacity ⁽⁹⁾</b>: {{ device_details.capacity }} kW</p>
-        <p><b>Commissioning Date ⁽¹⁰⁾</b>: {{ device_details.commissioningDate | date: 'dd MMM y hh:mm' }}</p>
-        <p><b>OnBoarding Date</b>: {{ device_details.createdAt | date: 'dd MMM y hh:mm' }}</p>
-        <p *ngIf="device_details.dataSource"><b>Data Source</b>: {{ device_details.dataSource }}</p>
-        <p *ngIf="device_details.otherDataSource"><b>Other Data Source</b>: {{ device_details.otherDataSource }}</p>
-        <p *ngIf="device_details.dataSourceBrand"><b>Data Source Brand</b>: {{ device_details.dataSourceBrand }}</p>
-        <p *ngIf="device_details.operatingConfiguration"><b>Operating Configuration</b>: {{ device_details.operatingConfiguration }}</p>
-        <p *ngIf="device_details.sourceAccessMode"><b>Source Access Mode ⁽²²⁾</b>: {{ device_details.sourceAccessMode }}</p>
+        <p>
+          <b>Commissioning Date ⁽¹⁰⁾</b>:
+          {{ device_details.commissioningDate | date: 'dd MMM y hh:mm' }}
+        </p>
+        <p>
+          <b>OnBoarding Date</b>:
+          {{ device_details.createdAt | date: 'dd MMM y hh:mm' }}
+        </p>
+        <p *ngIf="device_details.dataSource">
+          <b>Data Source</b>: {{ device_details.dataSource }}
+        </p>
+        <p *ngIf="device_details.otherDataSource">
+          <b>Other Data Source</b>: {{ device_details.otherDataSource }}
+        </p>
+        <p *ngIf="device_details.dataSourceBrand">
+          <b>Data Source Brand</b>: {{ device_details.dataSourceBrand }}
+        </p>
+        <p *ngIf="device_details.operatingConfiguration">
+          <b>Operating Configuration</b>:
+          {{ device_details.operatingConfiguration }}
+        </p>
+        <p *ngIf="device_details.sourceAccessMode">
+          <b>Source Access Mode ⁽²²⁾</b>: {{ device_details.sourceAccessMode }}
+        </p>
 
         <h3 class="section-heading">Facility Technical</h3>
-        <p *ngIf="device_details.generatingUnitCount"><b>Number of Generating Units ⁽¹³⁾</b>: {{ device_details.generatingUnitCount }}</p>
-        <p *ngIf="device_details.networkOwner"><b>Network Owner ⁽¹⁷⁾</b>: {{ device_details.networkOwner }}</p>
-        <p *ngIf="device_details.interconnectionVoltage"><b>Interconnection Voltage ⁽¹⁸⁾</b>: {{ device_details.interconnectionVoltage }}</p>
+        <p *ngIf="device_details.generatingUnitCount">
+          <b>Number of Generating Units ⁽¹³⁾</b>:
+          {{ device_details.generatingUnitCount }}
+        </p>
+        <p *ngIf="device_details.networkOwner">
+          <b>Network Owner ⁽¹⁷⁾</b>: {{ device_details.networkOwner }}
+        </p>
+        <p *ngIf="device_details.interconnectionVoltage">
+          <b>Interconnection Voltage ⁽¹⁸⁾</b>:
+          {{ device_details.interconnectionVoltage }}
+        </p>
 
         <h3 class="section-heading">Location</h3>
         <p><b>Address ⁽²⁾</b>: {{ device_details.address }}</p>
-        <p><b>State/Province/County ⁽³⁾</b>: {{ device_details.stateProvince || '—' }}</p>
-        <p><b>Postcode (Zip Code) ⁽⁴⁾</b>: {{ device_details.postcode || '—' }}</p>
+        <p>
+          <b>State/Province/County ⁽³⁾</b>:
+          {{ device_details.stateProvince || '—' }}
+        </p>
+        <p>
+          <b>Postcode (Zip Code) ⁽⁴⁾</b>: {{ device_details.postcode || '—' }}
+        </p>
         <p><b>Country ⁽⁵⁾</b>: {{ device_details.countryname || '—' }}</p>
         <p><b>Timezone</b>: {{ device_details.timezone }}</p>
         <p><b>Latitude ⁽⁶⁾</b>: {{ device_details.latitude }}</p>
         <p><b>Longitude ⁽⁷⁾</b>: {{ device_details.longitude }}</p>
-        <div *ngIf="satPreview"
-             style="width:256px;height:256px;overflow:hidden;position:relative;border-radius:4px;margin-top:8px;border:1px solid #cbd5e1">
-          <div [style.left.px]="satPreview.offsetX" [style.top.px]="satPreview.offsetY" style="position:absolute">
-            <img *ngFor="let t of satPreview.tiles" [src]="t.url" width="256" height="256"
-                 [style.position]="'absolute'" [style.left.px]="t.left" [style.top.px]="t.top" alt="" />
+        <div
+          *ngIf="satPreview"
+          style="
+            width: 256px;
+            height: 256px;
+            overflow: hidden;
+            position: relative;
+            border-radius: 4px;
+            margin-top: 8px;
+            border: 1px solid #cbd5e1;
+          "
+        >
+          <div
+            [style.left.px]="satPreview.offsetX"
+            [style.top.px]="satPreview.offsetY"
+            style="position: absolute"
+          >
+            <img
+              *ngFor="let t of satPreview.tiles"
+              [src]="t.url"
+              width="256"
+              height="256"
+              [style.position]="'absolute'"
+              [style.left.px]="t.left"
+              [style.top.px]="t.top"
+              alt=""
+            />
           </div>
         </div>
 
         <h3 class="section-heading">Ownership & Incentives</h3>
-        <p *ngIf="device_details.pvSystemOwner"><b>PV System Owner ⁽²⁷⁾</b>: {{ device_details.pvSystemOwner }}</p>
-        <p *ngIf="device_details.offTakerName"><b>Off-Taker Name ⁽²⁸⁾</b>: {{ device_details.offTakerName }}</p>
-        <p *ngIf="device_details.offTakerSameCompanyAsOwner"><b>Off-Taker Same as Owner ⁽³⁰⁾</b>: {{ device_details.offTakerSameCompanyAsOwner }}</p>
-        <p><b>Ownership Status</b>: {{ device_details.ownershipStatus || 'unverified' }}</p>
-        <p *ngIf="device_details.hasSubsidy"><b>Subsidy Received ⁽³⁴⁾</b>: {{ device_details.hasSubsidy }}</p>
-        <p *ngIf="device_details.subsidyTypes?.length"><b>Subsidy Types ⁽³⁵⁾</b>: {{ device_details.subsidyTypes.join(', ') }}</p>
-        <p *ngIf="device_details.subsidyOtherDetails"><b>Subsidy Other Details ⁽³⁵⁾</b>: {{ device_details.subsidyOtherDetails }}</p>
-        <p *ngIf="device_details.subsidyClaimsEacs"><b>Subsidy Claims EACs ⁽³⁶⁾</b>: {{ device_details.subsidyClaimsEacs }}</p>
-        <p *ngIf="device_details.hasPublicFunding"><b>Public Funding ⁽³²⁾</b>: {{ device_details.hasPublicFunding }}</p>
-        <p *ngIf="device_details.publicFundingEndDate"><b>Public Funding End Date ⁽³³⁾</b>: {{ device_details.publicFundingEndDate }}</p>
-        <p *ngIf="device_details.publicFundingType"><b>Public Funding Type</b>: {{ device_details.publicFundingType }}</p>
+        <p *ngIf="device_details.pvSystemOwner">
+          <b>PV System Owner ⁽²⁷⁾</b>: {{ device_details.pvSystemOwner }}
+        </p>
+        <p *ngIf="device_details.offTakerName">
+          <b>Off-Taker Name ⁽²⁸⁾</b>: {{ device_details.offTakerName }}
+        </p>
+        <p *ngIf="device_details.offTakerSameCompanyAsOwner">
+          <b>Off-Taker Same as Owner ⁽³⁰⁾</b>:
+          {{ device_details.offTakerSameCompanyAsOwner }}
+        </p>
+        <p>
+          <b>Ownership Status</b>:
+          {{ device_details.ownershipStatus || 'unverified' }}
+        </p>
+        <p *ngIf="device_details.hasSubsidy">
+          <b>Subsidy Received ⁽³⁴⁾</b>: {{ device_details.hasSubsidy }}
+        </p>
+        <p *ngIf="device_details.subsidyTypes?.length">
+          <b>Subsidy Types ⁽³⁵⁾</b>:
+          {{ device_details.subsidyTypes.join(', ') }}
+        </p>
+        <p *ngIf="device_details.subsidyOtherDetails">
+          <b>Subsidy Other Details ⁽³⁵⁾</b>:
+          {{ device_details.subsidyOtherDetails }}
+        </p>
+        <p *ngIf="device_details.subsidyClaimsEacs">
+          <b>Subsidy Claims EACs ⁽³⁶⁾</b>:
+          {{ device_details.subsidyClaimsEacs }}
+        </p>
+        <p *ngIf="device_details.hasPublicFunding">
+          <b>Public Funding ⁽³²⁾</b>: {{ device_details.hasPublicFunding }}
+        </p>
+        <p *ngIf="device_details.publicFundingEndDate">
+          <b>Public Funding End Date ⁽³³⁾</b>:
+          {{ device_details.publicFundingEndDate }}
+        </p>
+        <p *ngIf="device_details.publicFundingType">
+          <b>Public Funding Type</b>: {{ device_details.publicFundingType }}
+        </p>
 
         <h3 class="section-heading">Business Details</h3>
-        <p *ngIf="device_details.hasCaptiveConsumer"><b>Captive Consumer ⁽²³⁾</b>: {{ device_details.hasCaptiveConsumer }}</p>
-        <p *ngIf="device_details.hasAuxiliaryEnergySources"><b>Auxiliary Energy Sources ⁽²⁴⁾</b>: {{ device_details.hasAuxiliaryEnergySources }}</p>
-        <p *ngIf="device_details.auxiliaryEnergySourceDetails"><b>Auxiliary Source Details ⁽²⁵⁾</b>: {{ device_details.auxiliaryEnergySourceDetails }}</p>
-        <p *ngIf="device_details.nonMeterImportDetails"><b>Non-Meter Import Details ⁽²¹⁾</b>: {{ device_details.nonMeterImportDetails }}</p>
-        <p *ngIf="device_details.otherEacSchemeRegistration"><b>Other EAC Scheme Registration ⁽³¹⁾</b>: {{ device_details.otherEacSchemeRegistration }}</p>
-        <p *ngIf="device_details.additionalInfo"><b>Additional Info ⁽⁴⁰⁾</b>: {{ device_details.additionalInfo }}</p>
-        <p *ngIf="device_details.labellingSchemeAccreditation"><b>Labelling Scheme ⁽³⁷⁾</b>: {{ device_details.labellingSchemeAccreditation }}</p>
-        <p *ngIf="device_details.offGridCircumstances"><b>Off-Grid Circumstances</b>: {{ device_details.offGridCircumstances }}</p>
+        <p *ngIf="device_details.hasCaptiveConsumer">
+          <b>Captive Consumer ⁽²³⁾</b>: {{ device_details.hasCaptiveConsumer }}
+        </p>
+        <p *ngIf="device_details.hasAuxiliaryEnergySources">
+          <b>Auxiliary Energy Sources ⁽²⁴⁾</b>:
+          {{ device_details.hasAuxiliaryEnergySources }}
+        </p>
+        <p *ngIf="device_details.auxiliaryEnergySourceDetails">
+          <b>Auxiliary Source Details ⁽²⁵⁾</b>:
+          {{ device_details.auxiliaryEnergySourceDetails }}
+        </p>
+        <p *ngIf="device_details.nonMeterImportDetails">
+          <b>Non-Meter Import Details ⁽²¹⁾</b>:
+          {{ device_details.nonMeterImportDetails }}
+        </p>
+        <p *ngIf="device_details.otherEacSchemeRegistration">
+          <b>Other EAC Scheme Registration ⁽³¹⁾</b>:
+          {{ device_details.otherEacSchemeRegistration }}
+        </p>
+        <p *ngIf="device_details.additionalInfo">
+          <b>Additional Info ⁽⁴⁰⁾</b>: {{ device_details.additionalInfo }}
+        </p>
+        <p *ngIf="device_details.labellingSchemeAccreditation">
+          <b>Labelling Scheme ⁽³⁷⁾</b>:
+          {{ device_details.labellingSchemeAccreditation }}
+        </p>
+        <p *ngIf="device_details.offGridCircumstances">
+          <b>Off-Grid Circumstances</b>:
+          {{ device_details.offGridCircumstances }}
+        </p>
 
         <h3 class="section-heading">Evidence Pathway & Signature</h3>
-        <p *ngIf="device_details.signatoryName"><b>Signatory Name ⁽⁴¹⁾</b>: {{ device_details.signatoryName }}</p>
-        <p *ngIf="device_details.gridInterconnection != null"><b>Grid Connected ⁽¹⁵⁾</b>: {{ device_details.gridInterconnection ? 'Yes' : 'No' }}</p>
-        <p *ngIf="device_details.gridExportType"><b>Grid Export Type ⁽¹⁶⁾</b>: {{ device_details.gridExportType }}</p>
-        <p *ngIf="device_details.hasNetworkMeter"><b>Network Meter ⁽¹⁹⁾</b>: {{ device_details.hasNetworkMeter }}</p>
-        <p *ngIf="device_details.meterReadsShareable"><b>Meter Reads Shareable ⁽²⁰⁾</b>: {{ device_details.meterReadsShareable }}</p>
+        <p *ngIf="device_details.signatoryName">
+          <b>Signatory Name ⁽⁴¹⁾</b>: {{ device_details.signatoryName }}
+        </p>
+        <p *ngIf="device_details.gridInterconnection != null">
+          <b>Grid Connected ⁽¹⁵⁾</b>:
+          {{ device_details.gridInterconnection ? 'Yes' : 'No' }}
+        </p>
+        <p *ngIf="device_details.gridExportType">
+          <b>Grid Export Type ⁽¹⁶⁾</b>: {{ device_details.gridExportType }}
+        </p>
+        <p *ngIf="device_details.hasNetworkMeter">
+          <b>Network Meter ⁽¹⁹⁾</b>: {{ device_details.hasNetworkMeter }}
+        </p>
+        <p *ngIf="device_details.meterReadsShareable">
+          <b>Meter Reads Shareable ⁽²⁰⁾</b>:
+          {{ device_details.meterReadsShareable }}
+        </p>
 
         <h3 class="section-heading">Classification & Impact</h3>
         <p><b>Off Takers ⁽²⁹⁾</b>: {{ device_details.offTaker }}</p>
         <p><b>SDG Benefits ⁽³⁸⁾</b>: {{ device_details.SDGBenefits }}</p>
-        <p *ngIf="device_details.impactStory"><b>Impact Story ⁽³⁹⁾</b>: {{ device_details.impactStory }}</p>
+        <p *ngIf="device_details.impactStory">
+          <b>Impact Story ⁽³⁹⁾</b>: {{ device_details.impactStory }}
+        </p>
         <p><b>Version</b>: {{ device_details.version }}</p>
         <p><b>Yield Value</b>: {{ device_details.yieldValue }}</p>
         <p><b>Meter Read Type</b>: {{ device_details.meterReadtype }}</p>
-        <p><b>Device Description ⁽⁸⁾</b>: {{ device_details.deviceDescription }}</p>
-        <p *ngIf="device_details.reviewStatus"><b>Review Status</b>: {{ device_details.reviewStatus }}</p>
+        <p>
+          <b>Device Description ⁽⁸⁾</b>: {{ device_details.deviceDescription }}
+        </p>
+        <p *ngIf="device_details.reviewStatus">
+          <b>Review Status</b>: {{ device_details.reviewStatus }}
+        </p>
         <p><b>Evident Device ID</b>: {{ device_details.evidentDeviceId }}</p>
         <p><b>Evident Status</b>: {{ device_details.evidentStatus }}</p>
 
-        <h3 class="section-heading">Documents <span style="font-weight:400;color:#64748b;font-size:12px;">({{ documents.length }} file{{ documents.length === 1 ? '' : 's' }} loaded)</span></h3>
-        <ng-container *ngFor="let row of [
-          {label: 'Project Photos', oc: '⁽⁴³⁾', type: 'PROJECT_PHOTOS'},
-          {label: 'Single Line Diagram', oc: '⁽⁴⁵⁾', type: 'SINGLE_LINE_DIAGRAM'},
-          {label: 'SF-02c (Owner\'s Declaration)', oc: '⁽⁴⁶⁾', type: 'SF_02C'},
-          {label: 'Proof of Ownership', oc: '⁽⁴⁷⁾', type: 'SF_02C_OWNERS_DECLARATION'},
-          {label: 'COD Proof', oc: '⁽⁴⁸⁾', type: 'COD_PROOF'},
-          {label: 'Metering Evidence', oc: '⁽⁴⁹⁾', type: 'METERING_EVIDENCE'},
-          {label: 'Other Documents', oc: '⁽⁵⁰⁾', type: 'OTHER_DOCUMENTS'}
-        ]">
+        <h3 class="section-heading">
+          Documents
+          <span style="font-weight: 400; color: #64748b; font-size: 12px"
+            >({{ documents.length }} file{{
+              documents.length === 1 ? '' : 's'
+            }}
+            loaded)</span
+          >
+        </h3>
+        <ng-container
+          *ngFor="
+            let row of [
+              { label: 'Project Photos', oc: '⁽⁴³⁾', type: 'PROJECT_PHOTOS' },
+              {
+                label: 'Single Line Diagram',
+                oc: '⁽⁴⁵⁾',
+                type: 'SINGLE_LINE_DIAGRAM'
+              },
+              {
+                label: 'SF-02c (Owner\'s Declaration)',
+                oc: '⁽⁴⁶⁾',
+                type: 'SF_02C'
+              },
+              {
+                label: 'Proof of Ownership',
+                oc: '⁽⁴⁷⁾',
+                type: 'SF_02C_OWNERS_DECLARATION'
+              },
+              { label: 'COD Proof', oc: '⁽⁴⁸⁾', type: 'COD_PROOF' },
+              {
+                label: 'Metering Evidence',
+                oc: '⁽⁴⁹⁾',
+                type: 'METERING_EVIDENCE'
+              },
+              { label: 'Other Documents', oc: '⁽⁵⁰⁾', type: 'OTHER_DOCUMENTS' }
+            ]
+          "
+        >
           <p>
-            <b>{{ row.label }} {{ row.oc }}</b>:
+            <b>{{ row.label }} {{ row.oc }}</b
+            >:
             <ng-container *ngIf="docsOf(row.type).length; else noDocs">
               <ng-container *ngFor="let d of docsOf(row.type); let last = last">
-                <a href="#" (click)="openDocLink(d.id, $event)">{{ docLinkLabel(d) }}</a><span *ngIf="!last">, </span>
+                <a href="#" (click)="openDocLink(d.id, $event)">{{
+                  docLinkLabel(d)
+                }}</a
+                ><span *ngIf="!last">, </span>
               </ng-container>
             </ng-container>
             <ng-template #noDocs>—</ng-template>
@@ -137,12 +308,14 @@
       </div>
     </ng-template>
   </mat-dialog-content>
-  <hr style="margin:8px 0" *ngIf="!loading" />
+  <hr style="margin: 8px 0" *ngIf="!loading" />
   <mat-dialog-actions align="end" *ngIf="!loading">
     <button mat-button (click)="copyToClipboard()">
       <mat-icon class="me-1">content_copy</mat-icon> Copy
     </button>
     <button mat-button (click)="dialogRef.close(false)">Cancel</button>
-    <button mat-flat-button color="primary" (click)="dialogRef.close(false)">OK</button>
+    <button mat-flat-button color="primary" (click)="dialogRef.close(false)">
+      OK
+    </button>
   </mat-dialog-actions>
 </div>

--- a/src/app/view/redemption-report/redemption-report.component.html
+++ b/src/app/view/redemption-report/redemption-report.component.html
@@ -73,7 +73,7 @@
             </td>
           </ng-container>
           <ng-container matColumnDef="capacityRange">
-            <th mat-header-cell *matHeaderCellDef>Capacity Range</th>
+            <th mat-header-cell *matHeaderCellDef>Capacity Range (kW)</th>
             <td mat-cell *matCellDef="let element">
               {{ element.capacityRange }}
             </td>

--- a/src/app/view/redemption-report/redemption-report.component.html
+++ b/src/app/view/redemption-report/redemption-report.component.html
@@ -8,12 +8,7 @@
     <hr />
     <mat-card-content>
       <div class="content">
-        <table
-          mat-table
-          [dataSource]="dataSource"
-          
-          matSort
-        >
+        <table mat-table [dataSource]="dataSource" matSort>
           <ng-container matColumnDef="certificateId">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>
               CertificateId


### PR DESCRIPTION
Two small, topically adjacent fixes:

## Capacity labels

- Render `kW` explicitly in capacity displays that were unlabelled (device-details dialog, aggregate-capacity column, redemption-report "Capacity Range" header).
- Rename "Target Capacity (MWh)" → "Target Volume (MWh)" in the device-group form and the group-list read-out: MWh is energy, not a capacity. Matches the underlying field name `targetVolumeInMegaWattHour`.

Policy this aligns with: any capacity display/input in the UI must be kW.

## Sidemenu submenu indent

Parent headers use \`flex-direction: row-reverse\` (triangle on the left), which pushes parent text right. Submenu items were padded at the panel body's left edge, so they visually landed to the **left** of their parent. Bumped \`.inside-menu-button\` left padding so submenus sit indented to the right, as expected.

## Out of scope

- kVA tooltip examples for diesel gensets (\`add-devices:411\`, \`edit-device:310\`) — left as-is; kVA is industry-correct for genset nameplate ratings.
- Backend field name \`targetCapacityInMegaWattHour\` vs \`targetVolumeInMegaWattHour\` inconsistency — unchanged; out of scope for a UI PR.