### PR TITLE
chore: apply prettier across the repo (unblock lint-prettier CI)

### DIFF
--- a/src/app/auth/services/bulk-upload.service.ts
+++ b/src/app/auth/services/bulk-upload.service.ts
@@ -62,12 +62,18 @@ export class BulkUploadService {
     return this.http.get(Url);
   }
 
-  getBulkUploadPreview(
-    bulkUploadId: string,
-  ): Observable<{ records: any[]; organizationId: number; totalCsvRows: number; skippedRows: number }> {
-    return this.http.get<{ records: any[]; organizationId: number; totalCsvRows: number; skippedRows: number }>(
-      `${this.baseUrl}/${bulkUploadId}/preview`,
-    );
+  getBulkUploadPreview(bulkUploadId: string): Observable<{
+    records: any[];
+    organizationId: number;
+    totalCsvRows: number;
+    skippedRows: number;
+  }> {
+    return this.http.get<{
+      records: any[];
+      organizationId: number;
+      totalCsvRows: number;
+      skippedRows: number;
+    }>(`${this.baseUrl}/${bulkUploadId}/preview`);
   }
 
   confirmBulkUpload(

--- a/src/app/auth/services/device.service.ts
+++ b/src/app/auth/services/device.service.ts
@@ -118,9 +118,7 @@ export class DeviceService {
   getDeviceInfoBYexternalId(externalid: string): Observable<any> {
     return this.httpClient.get(this.url + 'device/externalId/' + externalid);
   }
-  getDocuments(
-    deviceId: number,
-  ): Observable<
+  getDocuments(deviceId: number): Observable<
     {
       type: string;
       url: string;

--- a/src/app/auth/services/org-api-licenses.service.ts
+++ b/src/app/auth/services/org-api-licenses.service.ts
@@ -25,9 +25,7 @@ export class OrgApiLicensesService {
   constructor(private httpClient: HttpClient) {}
 
   getSettings(): Observable<LicenseSettings> {
-    return this.httpClient.get<LicenseSettings>(
-      this.url + 'org-api-licenses',
-    );
+    return this.httpClient.get<LicenseSettings>(this.url + 'org-api-licenses');
   }
 
   saveSettings(data: {

--- a/src/app/auth/services/webhook.service.ts
+++ b/src/app/auth/services/webhook.service.ts
@@ -31,11 +31,23 @@ export class WebhookService {
     return this.http.get<Webhook>(`${this.apiUrl}/${id}`);
   }
 
-  create(data: { url: string; events: string[]; secret?: string }): Observable<Webhook> {
+  create(data: {
+    url: string;
+    events: string[];
+    secret?: string;
+  }): Observable<Webhook> {
     return this.http.post<Webhook>(this.apiUrl, data);
   }
 
-  update(id: number, data: Partial<{ url: string; events: string[]; secret: string; active: boolean }>): Observable<Webhook> {
+  update(
+    id: number,
+    data: Partial<{
+      url: string;
+      events: string[];
+      secret: string;
+      active: boolean;
+    }>,
+  ): Observable<Webhook> {
     return this.http.patch<Webhook>(`${this.apiUrl}/${id}`, data);
   }
 
@@ -44,6 +56,9 @@ export class WebhookService {
   }
 
   test(id: number): Observable<{ success: boolean }> {
-    return this.http.post<{ success: boolean }>(`${this.apiUrl}/${id}/test`, {});
+    return this.http.post<{ success: boolean }>(
+      `${this.apiUrl}/${id}/test`,
+      {},
+    );
   }
 }

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -81,10 +81,13 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
           ) {
             incomingCount++;
             this.unreadUuids.add(msg.uuid);
-            this.boldTimers.set(msg.uuid, setTimeout(() => {
-              this.unreadUuids.delete(msg.uuid);
-              this.boldTimers.delete(msg.uuid);
-            }, 10000));
+            this.boldTimers.set(
+              msg.uuid,
+              setTimeout(() => {
+                this.unreadUuids.delete(msg.uuid);
+                this.boldTimers.delete(msg.uuid);
+              }, 10000),
+            );
           }
         }
       }
@@ -95,7 +98,9 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
       // Auto-mark conversation as read so the bell badge doesn't
       // count messages the reviewer is already looking at
       if (incomingCount > 0 && this.chatService.currentConversationId) {
-        this.chatService.markConversationRead(this.chatService.currentConversationId);
+        this.chatService.markConversationRead(
+          this.chatService.currentConversationId,
+        );
         this.playNotificationSound();
         this.flashHeader();
       }
@@ -328,7 +333,8 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
 
   private playNotificationSound(): void {
     try {
-      const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+      const ctx = new (window.AudioContext ||
+        (window as any).webkitAudioContext)();
       const osc = ctx.createOscillator();
       const gain = ctx.createGain();
       osc.connect(gain);
@@ -339,7 +345,9 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
       osc.start();
       gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.15);
       osc.stop(ctx.currentTime + 0.15);
-    } catch { /* audio not available */ }
+    } catch {
+      /* audio not available */
+    }
   }
 
   private flashHeader(): void {

--- a/src/app/chat/chat.service.ts
+++ b/src/app/chat/chat.service.ts
@@ -78,17 +78,13 @@ export class ChatService implements OnDestroy {
     });
   }
 
-  private getUnreadCount(
-    email: string,
-  ): Observable<{ count: number }> {
+  private getUnreadCount(email: string): Observable<{ count: number }> {
     return this.http.get<{ count: number }>(
       `${this.apiUrl}chat/unread-count/${encodeURIComponent(email)}`,
     );
   }
 
-  getUnreadDeviceNames(
-    email: string,
-  ): Observable<string[]> {
+  getUnreadDeviceNames(email: string): Observable<string[]> {
     return this.http.get<string[]>(
       `${this.apiUrl}chat/unread-devices/${encodeURIComponent(email)}`,
     );
@@ -98,10 +94,9 @@ export class ChatService implements OnDestroy {
     const email = this.getCurrentUserEmail();
     if (!email) return;
     this.http
-      .patch<any>(
-        `${this.apiUrl}chat/conversations/${conversationId}/read`,
-        { email },
-      )
+      .patch<any>(`${this.apiUrl}chat/conversations/${conversationId}/read`, {
+        email,
+      })
       .subscribe(() => this.fetchUnreadCount(email));
   }
 

--- a/src/app/nav/header/header.component.ts
+++ b/src/app/nav/header/header.component.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit, OnDestroy, Output, EventEmitter } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  Output,
+  EventEmitter,
+} from '@angular/core';
 import { AuthbaseService } from '../../auth/authbase.service';
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
@@ -46,19 +52,21 @@ export class HeaderComponent implements OnInit, OnDestroy {
     const email = this.chatService.getCurrentUserEmail();
     if (!email) return;
 
-    this.chatService.getUnreadDeviceNames(email).subscribe((names: string[]) => {
-      const devices = new Set(names);
-      this.chatService.unreadDevices$.next(devices);
+    this.chatService
+      .getUnreadDeviceNames(email)
+      .subscribe((names: string[]) => {
+        const devices = new Set(names);
+        this.chatService.unreadDevices$.next(devices);
 
-      if (devices.size === 0) return;
+        if (devices.size === 0) return;
 
-      if (devices.size === 1) {
-        this.openChatForDevice(Array.from(devices)[0]);
-      } else {
-        this.unreadDeviceNames = Array.from(devices);
-        this.showUnreadList = !this.showUnreadList;
-      }
-    });
+        if (devices.size === 1) {
+          this.openChatForDevice(Array.from(devices)[0]);
+        } else {
+          this.unreadDeviceNames = Array.from(devices);
+          this.showUnreadList = !this.showUnreadList;
+        }
+      });
   }
 
   openChatForDevice(deviceName: string): void {
@@ -66,17 +74,24 @@ export class HeaderComponent implements OnInit, OnDestroy {
     const email = this.chatService.getCurrentUserEmail();
     if (!email) return;
 
-    this.chatService.getConversation(undefined, undefined, deviceName).subscribe({
-      next: (conv) => {
-        if (!conv) return;
-        // Only open if the current user is a participant
-        if (conv.participant1 !== email && conv.participant2 !== email) return;
-        const partner = conv.participant1 === email ? conv.participant2 : conv.participant1;
-        this.chatService.siteName$.next(deviceName);
-        this.chatService.openForDevice$.next({ submitterEmail: partner, siteName: deviceName });
-        this.chatService.isChatOpen$.next(true);
-      },
-    });
+    this.chatService
+      .getConversation(undefined, undefined, deviceName)
+      .subscribe({
+        next: (conv) => {
+          if (!conv) return;
+          // Only open if the current user is a participant
+          if (conv.participant1 !== email && conv.participant2 !== email)
+            return;
+          const partner =
+            conv.participant1 === email ? conv.participant2 : conv.participant1;
+          this.chatService.siteName$.next(deviceName);
+          this.chatService.openForDevice$.next({
+            submitterEmail: partner,
+            siteName: deviceName,
+          });
+          this.chatService.isChatOpen$.next(true);
+        },
+      });
   }
 
   ngOnDestroy(): void {

--- a/src/app/nav/sidemenu/sidemenu.component.ts
+++ b/src/app/nav/sidemenu/sidemenu.component.ts
@@ -27,7 +27,14 @@ const DEFAULT_WIDTH = 200;
   templateUrl: './sidemenu.component.html',
   styleUrls: ['./sidemenu.component.scss'],
   providers: [
-    { provide: MAT_EXPANSION_PANEL_DEFAULT_OPTIONS, useValue: { expandedHeight: '32px', collapsedHeight: '32px', togglePosition: 'before' } },
+    {
+      provide: MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,
+      useValue: {
+        expandedHeight: '32px',
+        collapsedHeight: '32px',
+        togglePosition: 'before',
+      },
+    },
   ],
 })
 export class SidemenuComponent implements OnInit, AfterViewInit, OnDestroy {
@@ -154,9 +161,10 @@ export class SidemenuComponent implements OnInit, AfterViewInit, OnDestroy {
     } else {
       this.devcieurl = '/device/AllList';
       this.Alluserurl = './admin/All_users';
-      this.adduserorg_url = this.loginuser?.role === 'Admin'
-        ? '/admin/add_user'
-        : '/organization/user/invitation';
+      this.adduserorg_url =
+        this.loginuser?.role === 'Admin'
+          ? '/admin/add_user'
+          : '/organization/user/invitation';
     }
   }
 

--- a/src/app/shared/directives/image-zoom-pan.directive.ts
+++ b/src/app/shared/directives/image-zoom-pan.directive.ts
@@ -70,8 +70,7 @@ export class ImageZoomPanDirective implements OnChanges, OnDestroy {
   }
 
   private apply(): void {
-    this.host.nativeElement.style.transform =
-      `translate(${this.tx}px, ${this.ty}px) scale(${this.scale})`;
+    this.host.nativeElement.style.transform = `translate(${this.tx}px, ${this.ty}px) scale(${this.scale})`;
   }
 
   @HostListener('wheel', ['$event'])
@@ -167,10 +166,16 @@ export class ImageZoomPanDirective implements OnChanges, OnDestroy {
       event.preventDefault();
       const dist = this.touchDist(event);
       const factor = dist / this.pinchStartDist;
-      const nextScale = this.clamp(this.pinchStartScale * factor, this.minScale, this.maxScale);
+      const nextScale = this.clamp(
+        this.pinchStartScale * factor,
+        this.minScale,
+        this.maxScale,
+      );
       const rect = this.host.nativeElement.getBoundingClientRect();
-      const cx = (event.touches[0].clientX + event.touches[1].clientX) / 2 - rect.left;
-      const cy = (event.touches[0].clientY + event.touches[1].clientY) / 2 - rect.top;
+      const cx =
+        (event.touches[0].clientX + event.touches[1].clientX) / 2 - rect.left;
+      const cy =
+        (event.touches[0].clientY + event.touches[1].clientY) / 2 - rect.top;
       this.setScaleAt(cx, cy, nextScale);
     } else if (event.touches.length === 1 && this.dragging) {
       event.preventDefault();

--- a/src/app/shared/error-toast/error-toast.component.ts
+++ b/src/app/shared/error-toast/error-toast.component.ts
@@ -46,7 +46,11 @@ import {
     <div *ngIf="options.progressBar">
       <div class="toast-progress" [style.width]="width() + '%'"></div>
     </div>
-    <button *ngIf="toastPackage.toastType === 'toast-error'" class="copy-btn" (click)="copyError($event)">
+    <button
+      *ngIf="toastPackage.toastType === 'toast-error'"
+      class="copy-btn"
+      (click)="copyError($event)"
+    >
       {{ copied ? 'Copied!' : 'Copy error' }}
     </button>
   `,

--- a/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.ts
+++ b/src/app/shared/oc-checklist-panel/oc-checklist-panel.component.ts
@@ -23,7 +23,11 @@ interface OcRow {
 }
 
 const OC_ROWS: OcRow[] = [
-  { n: 1, item: 'Site Name', compare: 'Cross check with: RMS, SLD, Proof of Ownership, OD letter' },
+  {
+    n: 1,
+    item: 'Site Name',
+    compare: 'Cross check with: RMS, SLD, Proof of Ownership, OD letter',
+  },
   { n: 2, item: 'Address', compare: '' },
   { n: 3, item: 'State/Province', compare: 'Cross check with: coordinates' },
   { n: 4, item: 'Postcode', compare: '' },
@@ -32,41 +36,142 @@ const OC_ROWS: OcRow[] = [
   { n: 7, item: 'Longitude', compare: 'Cross check with: site photos' },
   { n: 8, item: 'Installation Type', compare: 'Cross check with: site photos' },
   { n: 9, item: 'Total AC Capacity', compare: 'Cross check with: RMS, SLD' },
-  { n: 10, item: 'Commissioning Date', compare: 'Cross check with: Proof of COD, 1st day of generation data' },
+  {
+    n: 10,
+    item: 'Commissioning Date',
+    compare: 'Cross check with: Proof of COD, 1st day of generation data',
+  },
   { n: 11, item: 'Requested Effective Registration Date', compare: '' },
   { n: 12, item: 'Default Evident Account Code', compare: '' },
-  { n: 13, item: 'Number of generating units', compare: 'Cross check with: RMS, SLD' },
-  { n: 14, item: 'Meter or Measurement ID(s)', compare: 'Cross check with: RMS, SLD' },
-  { n: 15, item: 'Is this facility connected to the grid?', compare: 'Cross check with: SLD' },
-  { n: 16, item: 'Does this facility export to the grid?', compare: 'Cross check with: SLD' },
-  { n: 17, item: 'Owner of the network to which the Production Device is connected', compare: 'Cross check with: SLD' },
+  {
+    n: 13,
+    item: 'Number of generating units',
+    compare: 'Cross check with: RMS, SLD',
+  },
+  {
+    n: 14,
+    item: 'Meter or Measurement ID(s)',
+    compare: 'Cross check with: RMS, SLD',
+  },
+  {
+    n: 15,
+    item: 'Is this facility connected to the grid?',
+    compare: 'Cross check with: SLD',
+  },
+  {
+    n: 16,
+    item: 'Does this facility export to the grid?',
+    compare: 'Cross check with: SLD',
+  },
+  {
+    n: 17,
+    item: 'Owner of the network to which the Production Device is connected',
+    compare: 'Cross check with: SLD',
+  },
   { n: 18, item: 'Interconnection voltage', compare: '' },
-  { n: 19, item: 'If this facility is grid-connected, is there a utility or network meter installed at this site?', compare: 'Cross check with: SLD' },
-  { n: 20, item: 'If yes, can you share the meter reads from the network or utility meter via an official document (e.g. a utility bill or online dashboard)?', compare: 'Cross check with: sample metering evidence' },
-  { n: 21, item: 'Please give details of how the site can import electricity by means other than through the meter(s) specified above', compare: 'Cross check with: SLD' },
-  { n: 22, item: 'How will you share metering evidence for this site?', compare: 'Cross check with: sample metering evidence' },
-  { n: 23, item: 'Is there an on-site (captive) consumer present?', compare: 'Cross check with: Proof of ownership' },
-  { n: 24, item: 'Are there any auxiliary or standby energy sources present?', compare: 'Cross check with: SLD' },
+  {
+    n: 19,
+    item: 'If this facility is grid-connected, is there a utility or network meter installed at this site?',
+    compare: 'Cross check with: SLD',
+  },
+  {
+    n: 20,
+    item: 'If yes, can you share the meter reads from the network or utility meter via an official document (e.g. a utility bill or online dashboard)?',
+    compare: 'Cross check with: sample metering evidence',
+  },
+  {
+    n: 21,
+    item: 'Please give details of how the site can import electricity by means other than through the meter(s) specified above',
+    compare: 'Cross check with: SLD',
+  },
+  {
+    n: 22,
+    item: 'How will you share metering evidence for this site?',
+    compare: 'Cross check with: sample metering evidence',
+  },
+  {
+    n: 23,
+    item: 'Is there an on-site (captive) consumer present?',
+    compare: 'Cross check with: Proof of ownership',
+  },
+  {
+    n: 24,
+    item: 'Are there any auxiliary or standby energy sources present?',
+    compare: 'Cross check with: SLD',
+  },
   { n: 25, item: 'If yes, provide details', compare: 'Cross check with: SLD' },
-  { n: 26, item: 'Is the Registrant also the owner of the Production Facility?', compare: 'Cross check with: PV system owner' },
-  { n: 27, item: 'PV System Owner', compare: 'Cross check with: Proof of ownership' },
-  { n: 28, item: 'Off-taker Name', compare: 'Cross check with: Proof of ownership' },
+  {
+    n: 26,
+    item: 'Is the Registrant also the owner of the Production Facility?',
+    compare: 'Cross check with: PV system owner',
+  },
+  {
+    n: 27,
+    item: 'PV System Owner',
+    compare: 'Cross check with: Proof of ownership',
+  },
+  {
+    n: 28,
+    item: 'Off-taker Name',
+    compare: 'Cross check with: Proof of ownership',
+  },
   { n: 29, item: 'Off-taker Type', compare: '' },
-  { n: 30, item: 'Is the Electricity Off-taker part of the same company (or at least 51% part of the same company group) as the PV system owner?', compare: '' },
-  { n: 31, item: 'Please give details (including registration id) of any carbon offset or energy tracking scheme for which the Production Facility is registered. State "None" if that is the case', compare: 'If anything other than "None" is specified, registration cannot be approved' },
-  { n: 32, item: 'Has the Production Facility ever received public (government) funding (e.g. Feed in Tariff)?', compare: '' },
-  { n: 33, item: 'If public (government) funding has been received when did/will it finish?', compare: '' },
-  { n: 34, item: 'Has this facility ever received any form of subsidy or incentive?', compare: '"Yes" means individual senior review required' },
-  { n: 35, item: 'If yes, provide details', compare: 'All items mean individual senior review required' },
-  { n: 36, item: 'Do any applicable subsidies or incentives create a claim on the environmental attributes?', compare: '"Yes" means facility cannot be approved' },
-  { n: 37, item: 'Other Labelling Scheme', compare: 'If more labels are chosen, D-REC to pass on to relevant party' },
+  {
+    n: 30,
+    item: 'Is the Electricity Off-taker part of the same company (or at least 51% part of the same company group) as the PV system owner?',
+    compare: '',
+  },
+  {
+    n: 31,
+    item: 'Please give details (including registration id) of any carbon offset or energy tracking scheme for which the Production Facility is registered. State "None" if that is the case',
+    compare:
+      'If anything other than "None" is specified, registration cannot be approved',
+  },
+  {
+    n: 32,
+    item: 'Has the Production Facility ever received public (government) funding (e.g. Feed in Tariff)?',
+    compare: '',
+  },
+  {
+    n: 33,
+    item: 'If public (government) funding has been received when did/will it finish?',
+    compare: '',
+  },
+  {
+    n: 34,
+    item: 'Has this facility ever received any form of subsidy or incentive?',
+    compare: '"Yes" means individual senior review required',
+  },
+  {
+    n: 35,
+    item: 'If yes, provide details',
+    compare: 'All items mean individual senior review required',
+  },
+  {
+    n: 36,
+    item: 'Do any applicable subsidies or incentives create a claim on the environmental attributes?',
+    compare: '"Yes" means facility cannot be approved',
+  },
+  {
+    n: 37,
+    item: 'Other Labelling Scheme',
+    compare: 'If more labels are chosen, D-REC to pass on to relevant party',
+  },
   { n: 38, item: 'SDG Benefits', compare: '' },
   { n: 39, item: 'Impact Story', compare: '' },
-  { n: 40, item: 'Additional Information', compare: 'Individual review may be required depending on response' },
+  {
+    n: 40,
+    item: 'Additional Information',
+    compare: 'Individual review may be required depending on response',
+  },
   { n: 41, item: 'Name', compare: '' },
   { n: 42, item: 'Signature', compare: '' },
   { n: 43, item: 'Site photos', compare: 'Cross check with: coordinates, SLD' },
-  { n: 44, item: 'Facility boundary', compare: 'Cross check with: site photos, capacity' },
+  {
+    n: 44,
+    item: 'Facility boundary',
+    compare: 'Cross check with: site photos, capacity',
+  },
   {
     n: 45,
     item: 'Single Line Diagram (SLD)',
@@ -82,11 +187,34 @@ const OC_ROWS: OcRow[] = [
       'signature/stamp of facility owner or engineer',
     ],
   },
-  { n: 46, item: "Owner's Declaration Letter", compare: 'Cross check with: template language, PV system owner, site name, site address, coordinates, total AC capacity, commissioning date' },
-  { n: 47, item: 'Proof of Ownership and Rights to Transact', compare: 'Cross check with: PV system owner, Offtaker, OD letter, RE attributes' },
-  { n: 48, item: 'Proof of Commissioning Date', compare: 'Cross check with: COD, site name, first day of generation data' },
-  { n: 49, item: 'Sample metering evidence', compare: 'Cross check with: grid-status, export status, network meter availability, useable data access mode, site name, SLD, meter/measurement IDs' },
-  { n: 50, item: 'Other Documents', compare: 'Individual review may be required depending on response' },
+  {
+    n: 46,
+    item: "Owner's Declaration Letter",
+    compare:
+      'Cross check with: template language, PV system owner, site name, site address, coordinates, total AC capacity, commissioning date',
+  },
+  {
+    n: 47,
+    item: 'Proof of Ownership and Rights to Transact',
+    compare:
+      'Cross check with: PV system owner, Offtaker, OD letter, RE attributes',
+  },
+  {
+    n: 48,
+    item: 'Proof of Commissioning Date',
+    compare: 'Cross check with: COD, site name, first day of generation data',
+  },
+  {
+    n: 49,
+    item: 'Sample metering evidence',
+    compare:
+      'Cross check with: grid-status, export status, network meter availability, useable data access mode, site name, SLD, meter/measurement IDs',
+  },
+  {
+    n: 50,
+    item: 'Other Documents',
+    compare: 'Individual review may be required depending on response',
+  },
 ];
 
 @Component({
@@ -97,7 +225,9 @@ const OC_ROWS: OcRow[] = [
   styleUrls: ['./oc-checklist-panel.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class OcChecklistPanelComponent implements OnInit, OnChanges, AfterViewInit, OnDestroy {
+export class OcChecklistPanelComponent
+  implements OnInit, OnChanges, AfterViewInit, OnDestroy
+{
   /** localStorage key for persisting the checked set. If empty/null, state is session-only. */
   @Input() storageKey: string | null = '';
 
@@ -158,7 +288,9 @@ export class OcChecklistPanelComponent implements OnInit, OnChanges, AfterViewIn
 
   get visibleRows(): OcRow[] {
     if (!this.hideNoCrosscheck) return this.rows;
-    return this.rows.filter((r) => r.compare || (r.subItems && r.subItems.length > 0));
+    return this.rows.filter(
+      (r) => r.compare || (r.subItems && r.subItems.length > 0),
+    );
   }
 
   toggleHideNoCrosscheck(): void {
@@ -168,13 +300,17 @@ export class OcChecklistPanelComponent implements OnInit, OnChanges, AfterViewIn
         OcChecklistPanelComponent.HIDE_PREF_KEY,
         this.hideNoCrosscheck ? '1' : '0',
       );
-    } catch { /* noop */ }
+    } catch {
+      /* noop */
+    }
     this.cdr.markForCheck();
   }
 
   private loadHidePref(): boolean {
     try {
-      return localStorage.getItem(OcChecklistPanelComponent.HIDE_PREF_KEY) === '1';
+      return (
+        localStorage.getItem(OcChecklistPanelComponent.HIDE_PREF_KEY) === '1'
+      );
     } catch {
       return false;
     }
@@ -199,7 +335,10 @@ export class OcChecklistPanelComponent implements OnInit, OnChanges, AfterViewIn
   checkedLeaves(): number {
     return this.rows.reduce((acc, r) => {
       if (r.subItems?.length) {
-        return acc + r.subItems.filter((_, i) => this.checked.has(`${r.n}.${i}`)).length;
+        return (
+          acc +
+          r.subItems.filter((_, i) => this.checked.has(`${r.n}.${i}`)).length
+        );
       }
       return acc + (this.checked.has(String(r.n)) ? 1 : 0);
     }, 0);

--- a/src/app/shared/pdf-preview/pdf-preview.component.ts
+++ b/src/app/shared/pdf-preview/pdf-preview.component.ts
@@ -23,7 +23,13 @@ import { ImageZoomPanDirective } from '../directives/image-zoom-pan.directive';
 @Component({
   standalone: true,
   selector: 'app-pdf-preview',
-  imports: [CommonModule, FormsModule, MatIconModule, MatProgressSpinnerModule, ImageZoomPanDirective],
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    ImageZoomPanDirective,
+  ],
   templateUrl: './pdf-preview.component.html',
   styleUrls: ['./pdf-preview.component.scss'],
 })
@@ -93,10 +99,14 @@ export class PdfPreviewComponent implements OnChanges {
 
   private loadLeftWidthPct(): number {
     try {
-      const raw = localStorage.getItem(PdfPreviewComponent.LEFT_WIDTH_STORAGE_KEY);
+      const raw = localStorage.getItem(
+        PdfPreviewComponent.LEFT_WIDTH_STORAGE_KEY,
+      );
       const n = raw ? parseFloat(raw) : NaN;
       if (!isNaN(n) && n >= 20 && n <= 80) return n;
-    } catch { /* noop */ }
+    } catch {
+      /* noop */
+    }
     return 50;
   }
 
@@ -107,7 +117,10 @@ export class PdfPreviewComponent implements OnChanges {
     if (changes['sldDeviceId'] && this.sldDeviceId) {
       this.fetchSldCompare();
     }
-    if ((changes['ocrSource'] || changes['previewType']) && this.previewType === 'excel') {
+    if (
+      (changes['ocrSource'] || changes['previewType']) &&
+      this.previewType === 'excel'
+    ) {
       this.loadExcel();
     }
   }
@@ -140,7 +153,9 @@ export class PdfPreviewComponent implements OnChanges {
       const wb = XLSX.read(new Uint8Array(arrayBuffer), { type: 'array' });
       this.excelSheets = wb.SheetNames.map((name: string) => {
         const sheet = wb.Sheets[name];
-        const html: string = XLSX.utils.sheet_to_html(sheet, { editable: false });
+        const html: string = XLSX.utils.sheet_to_html(sheet, {
+          editable: false,
+        });
         return { name, html };
       });
       if (this.excelSheets.length === 0) {
@@ -161,7 +176,9 @@ export class PdfPreviewComponent implements OnChanges {
     this.sldLoading = true;
     this.sldSaved = false;
     this.http
-      .get<any>(`${environment.API_URL}device-reviews/${this.sldDeviceId}/sld-compare`)
+      .get<any>(
+        `${environment.API_URL}device-reviews/${this.sldDeviceId}/sld-compare`,
+      )
       .subscribe({
         next: (res) => {
           this.sldResult = res;
@@ -179,9 +196,12 @@ export class PdfPreviewComponent implements OnChanges {
     if (!this.sldDeviceId || this.sldInputKw == null) return;
     this.sldSaved = false;
     this.http
-      .patch<any>(`${environment.API_URL}device-reviews/${this.sldDeviceId}/sld-capacity`, {
-        sldCapacityKw: this.sldInputKw,
-      })
+      .patch<any>(
+        `${environment.API_URL}device-reviews/${this.sldDeviceId}/sld-capacity`,
+        {
+          sldCapacityKw: this.sldInputKw,
+        },
+      )
       .subscribe({
         next: () => {
           this.sldSaved = true;
@@ -228,7 +248,9 @@ export class PdfPreviewComponent implements OnChanges {
 
   onVerticalDragStart(event: MouseEvent): void {
     event.preventDefault();
-    const container = this.host.nativeElement.querySelector('.pdf-preview') as HTMLElement | null;
+    const container = this.host.nativeElement.querySelector(
+      '.pdf-preview',
+    ) as HTMLElement | null;
     if (!container) return;
     const rect = container.getBoundingClientRect();
     const onMove = (e: MouseEvent) => {
@@ -243,7 +265,9 @@ export class PdfPreviewComponent implements OnChanges {
           PdfPreviewComponent.LEFT_WIDTH_STORAGE_KEY,
           String(this.leftWidthPct),
         );
-      } catch { /* noop */ }
+      } catch {
+        /* noop */
+      }
     };
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
@@ -346,14 +370,14 @@ export class PdfPreviewComponent implements OnChanges {
         if (remaining <= 0) {
           alert(
             'DeepL credits exhausted.\n\n' +
-            'Please add your own DeepL API key in Organization > Licenses.',
+              'Please add your own DeepL API key in Organization > Licenses.',
           );
           return;
         }
         const ok = confirm(
           `You have ${remaining} free DeepL credit(s) remaining \u2014 proceed?\n\n` +
-          `This will use 1 credit. Once exhausted, you\u2019ll need to add ` +
-          `your own API key in Organization > Licenses.`,
+            `This will use 1 credit. Once exhausted, you\u2019ll need to add ` +
+            `your own API key in Organization > Licenses.`,
         );
         if (!ok) return;
       }
@@ -361,7 +385,7 @@ export class PdfPreviewComponent implements OnChanges {
       // Credits endpoint unavailable (dev mode) — show free tier warning
       const ok = confirm(
         'Translation uses the DeepL API free tier (500,000 characters/month). ' +
-        'Large documents consume quota quickly.\n\nProceed anyway?',
+          'Large documents consume quota quickly.\n\nProceed anyway?',
       );
       if (!ok) return;
     }
@@ -388,8 +412,7 @@ export class PdfPreviewComponent implements OnChanges {
         const t = data.translations?.[0];
         if (t) {
           if (!this.detectedLang)
-            this.detectedLang =
-              t.detected_source_language?.toLowerCase() || '';
+            this.detectedLang = t.detected_source_language?.toLowerCase() || '';
           this.translatedText += t.text;
         }
       }
@@ -453,19 +476,26 @@ export class PdfPreviewComponent implements OnChanges {
           return;
         }
         if (credits.roboflow.credits <= 0) {
-          this.detectError = 'Roboflow credits exhausted. Add your own API key in Organization > Licenses.';
+          this.detectError =
+            'Roboflow credits exhausted. Add your own API key in Organization > Licenses.';
           this.cdr.detectChanges();
           return;
         }
-        if (confirm(
-          `You have ${credits.roboflow.credits} free Roboflow credit(s) remaining — proceed?\n\n` +
-          `This will use 1 credit.`,
-        )) {
+        if (
+          confirm(
+            `You have ${credits.roboflow.credits} free Roboflow credit(s) remaining — proceed?\n\n` +
+              `This will use 1 credit.`,
+          )
+        ) {
           this.runDetection();
         }
       },
       error: () => {
-        if (confirm('Panel detection uses a limited number of free scans. Proceed anyway?')) {
+        if (
+          confirm(
+            'Panel detection uses a limited number of free scans. Proceed anyway?',
+          )
+        ) {
           this.runDetection();
         }
       },
@@ -481,7 +511,12 @@ export class PdfPreviewComponent implements OnChanges {
     this.detecting = false;
     if (this.detectCanvas?.nativeElement) {
       const ctx = this.detectCanvas.nativeElement.getContext('2d');
-      ctx?.clearRect(0, 0, this.detectCanvas.nativeElement.width, this.detectCanvas.nativeElement.height);
+      ctx?.clearRect(
+        0,
+        0,
+        this.detectCanvas.nativeElement.width,
+        this.detectCanvas.nativeElement.height,
+      );
     }
   }
 
@@ -508,7 +543,11 @@ export class PdfPreviewComponent implements OnChanges {
   }
 
   deleteSelectedRegion(): void {
-    if (this.selectedRegion < 0 || this.selectedRegion >= this.predictions.length) return;
+    if (
+      this.selectedRegion < 0 ||
+      this.selectedRegion >= this.predictions.length
+    )
+      return;
     this.predictions.splice(this.selectedRegion, 1);
     this.selectedRegion = -1;
     this.panelCount = this.predictions.length;
@@ -529,7 +568,10 @@ export class PdfPreviewComponent implements OnChanges {
 
     const canvas = document.createElement('canvas');
     const maxDim = 640;
-    const scale = Math.min(1, maxDim / Math.max(img.naturalWidth, img.naturalHeight));
+    const scale = Math.min(
+      1,
+      maxDim / Math.max(img.naturalWidth, img.naturalHeight),
+    );
     canvas.width = Math.round(img.naturalWidth * scale);
     canvas.height = Math.round(img.naturalHeight * scale);
     const ctx = canvas.getContext('2d')!;
@@ -554,7 +596,9 @@ export class PdfPreviewComponent implements OnChanges {
       const scale = Math.min(1, maxDim / Math.max(bmp.width, bmp.height));
       canvas.width = Math.round(bmp.width * scale);
       canvas.height = Math.round(bmp.height * scale);
-      canvas.getContext('2d')!.drawImage(bmp, 0, 0, canvas.width, canvas.height);
+      canvas
+        .getContext('2d')!
+        .drawImage(bmp, 0, 0, canvas.width, canvas.height);
       bmp.close();
       const base64 = canvas.toDataURL('image/jpeg', 0.6).split(',')[1];
       this.sendDetection(base64);
@@ -566,19 +610,25 @@ export class PdfPreviewComponent implements OnChanges {
   }
 
   private sendDetection(base64: string): void {
-    this.http.post<any>(
-      `${environment.API_URL}device-reviews/detect-panels`,
-      { image: base64 },
-    ).pipe(
-      retry({ count: 2, delay: (_err: any, attempt: number) => timer(attempt * 3000) }),
-    ).subscribe({
-      next: (data) => this.handleDetections(data),
-      error: (err) => {
-        this.detectError = 'Detection failed: ' + (err?.error?.message || err?.message || err);
-        this.detecting = false;
-        this.cdr.detectChanges();
-      },
-    });
+    this.http
+      .post<any>(`${environment.API_URL}device-reviews/detect-panels`, {
+        image: base64,
+      })
+      .pipe(
+        retry({
+          count: 2,
+          delay: (_err: any, attempt: number) => timer(attempt * 3000),
+        }),
+      )
+      .subscribe({
+        next: (data) => this.handleDetections(data),
+        error: (err) => {
+          this.detectError =
+            'Detection failed: ' + (err?.error?.message || err?.message || err);
+          this.detecting = false;
+          this.cdr.detectChanges();
+        },
+      });
   }
 
   private handleDetections(data: any): void {
@@ -617,12 +667,20 @@ export class PdfPreviewComponent implements OnChanges {
   private detectHitTest(pred: any, mx: number, my: number): boolean {
     const points: { x: number; y: number }[] = pred.points ?? [];
     if (points.length > 2) {
-      const scaled = points.map((p: any) => ({ x: p.x * this.detScaleX, y: p.y * this.detScaleY }));
+      const scaled = points.map((p: any) => ({
+        x: p.x * this.detScaleX,
+        y: p.y * this.detScaleY,
+      }));
       let inside = false;
       for (let i = 0, j = scaled.length - 1; i < scaled.length; j = i++) {
-        const xi = scaled[i].x, yi = scaled[i].y;
-        const xj = scaled[j].x, yj = scaled[j].y;
-        if (((yi > my) !== (yj > my)) && (mx < (xj - xi) * (my - yi) / (yj - yi) + xi)) {
+        const xi = scaled[i].x,
+          yi = scaled[i].y;
+        const xj = scaled[j].x,
+          yj = scaled[j].y;
+        if (
+          yi > my !== yj > my &&
+          mx < ((xj - xi) * (my - yi)) / (yj - yi) + xi
+        ) {
           inside = !inside;
         }
       }
@@ -643,7 +701,9 @@ export class PdfPreviewComponent implements OnChanges {
     for (let i = 0; i < this.predictions.length; i++) {
       const pred = this.predictions[i];
       const selected = i === this.selectedRegion;
-      const fill = selected ? 'rgba(239, 68, 68, 0.4)' : 'rgba(0, 255, 180, 0.3)';
+      const fill = selected
+        ? 'rgba(239, 68, 68, 0.4)'
+        : 'rgba(0, 255, 180, 0.3)';
       const stroke = selected ? '#ef4444' : '#00ffb4';
       const points: { x: number; y: number }[] = pred.points ?? [];
 
@@ -651,7 +711,10 @@ export class PdfPreviewComponent implements OnChanges {
         ctx.beginPath();
         ctx.moveTo(points[0].x * this.detScaleX, points[0].y * this.detScaleY);
         for (let j = 1; j < points.length; j++) {
-          ctx.lineTo(points[j].x * this.detScaleX, points[j].y * this.detScaleY);
+          ctx.lineTo(
+            points[j].x * this.detScaleX,
+            points[j].y * this.detScaleY,
+          );
         }
         ctx.closePath();
         ctx.fillStyle = fill;

--- a/src/app/shared/satellite-preview/satellite-preview.component.ts
+++ b/src/app/shared/satellite-preview/satellite-preview.component.ts
@@ -1,7 +1,10 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { SatellitePreview, satellitePreview } from '../../view/map/map.component';
+import {
+  SatellitePreview,
+  satellitePreview,
+} from '../../view/map/map.component';
 import { environment } from '../../../environments/environment';
 
 @Component({
@@ -34,9 +37,7 @@ import { environment } from '../../../environments/environment';
           />
         </div>
       </div>
-      <div class="sat-preview__date" *ngIf="satDate">
-        \u{1F6F0} {{ satDate }}
-      </div>
+      <div class="sat-preview__date" *ngIf="satDate">🛰 {{ satDate }}</div>
     </div>
   `,
   styles: [
@@ -162,10 +163,11 @@ export class SatellitePreviewComponent implements OnChanges {
     document.body.appendChild(el);
 
     http
-      .get<{ date: string | null }>(
-        `${environment.API_URL}device-reviews/satellite-date`,
-        { params: { lat: lat.toString(), lng: lng.toString() } },
-      )
+      .get<{
+        date: string | null;
+      }>(`${environment.API_URL}device-reviews/satellite-date`, {
+        params: { lat: lat.toString(), lng: lng.toString() },
+      })
       .subscribe({
         next: (res) => {
           if (res.date) {
@@ -203,12 +205,9 @@ export class SatellitePreviewComponent implements OnChanges {
     const boxH = 310;
     const gap = 16;
     const rightFits = screenX + gap + boxW < window.innerWidth;
-    el.style.left =
-      (rightFits ? screenX + gap : screenX - gap - boxW) + 'px';
+    el.style.left = (rightFits ? screenX + gap : screenX - gap - boxW) + 'px';
     el.style.top =
-      Math.min(
-        Math.max(screenY - boxH / 2, 4),
-        window.innerHeight - boxH - 4,
-      ) + 'px';
+      Math.min(Math.max(screenY - boxH / 2, 4), window.innerHeight - boxH - 4) +
+      'px';
   }
 }

--- a/src/app/utils/drec.enum.ts
+++ b/src/app/utils/drec.enum.ts
@@ -1,8 +1,4 @@
-export const UserStatus = [
-  'Pending',
-  'Active',
-  'Suspended',
-];
+export const UserStatus = ['Pending', 'Active', 'Suspended'];
 export enum UserEnumStatus {
   Pending = 'Pending',
   Active = 'Active',

--- a/src/app/utils/evidence-requirements.ts
+++ b/src/app/utils/evidence-requirements.ts
@@ -124,7 +124,10 @@ export const EVIDENCE_HINTS: Record<string, Record<string, string>> = {
   },
 };
 
-export function getHint(config: string | null | undefined, docType: string): string | null {
+export function getHint(
+  config: string | null | undefined,
+  docType: string,
+): string | null {
   if (!config) return null;
   return EVIDENCE_HINTS[config]?.[docType] ?? null;
 }

--- a/src/app/view/admin/admin-alldevices/admin-alldevices.component.ts
+++ b/src/app/view/admin/admin-alldevices/admin-alldevices.component.ts
@@ -17,7 +17,11 @@ import {
   devicecodeType,
   CountryInfo,
 } from '../../../models';
-import { MapComponent, satellitePreview, SatellitePreview } from '../../map/map.component';
+import {
+  MapComponent,
+  satellitePreview,
+  SatellitePreview,
+} from '../../map/map.component';
 @Component({
   standalone: false,
   selector: 'app-admin-alldevices',
@@ -51,7 +55,13 @@ export class AdminAlldevicesComponent {
   dataSource: MatTableDataSource<any>;
   data: any;
   searchText: string = '';
-  satPreview: { lat: number; lng: number; label: string; x: number; y: number } | null = null;
+  satPreview: {
+    lat: number;
+    lng: number;
+    label: string;
+    x: number;
+    y: number;
+  } | null = null;
   loginuser: any;
   deviceurl: any;
   pageSize: number = 20;
@@ -535,7 +545,10 @@ export class AdminAlldevicesComponent {
     const gap = 16;
     const rightFits = event.clientX + gap + boxW < window.innerWidth;
     const x = rightFits ? event.clientX + gap : event.clientX - gap - boxW;
-    const y = Math.min(Math.max(event.clientY - boxH / 2, 4), window.innerHeight - boxH - 4);
+    const y = Math.min(
+      Math.max(event.clientY - boxH / 2, 4),
+      window.innerHeight - boxH - 4,
+    );
     return { x, y };
   }
 

--- a/src/app/view/admin/webhooks/webhooks.component.ts
+++ b/src/app/view/admin/webhooks/webhooks.component.ts
@@ -1,5 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { WebhookService, Webhook } from '../../../auth/services/webhook.service';
+import {
+  WebhookService,
+  Webhook,
+} from '../../../auth/services/webhook.service';
 import { ToastrService } from 'ngx-toastr';
 
 @Component({
@@ -16,7 +19,10 @@ export class WebhooksComponent implements OnInit {
   showForm = false;
   editingId: number | null = null;
   formUrl = '';
-  formEvents: Record<string, boolean> = { 'message.new': true, 'conversation.created': true };
+  formEvents: Record<string, boolean> = {
+    'message.new': true,
+    'conversation.created': true,
+  };
   formActive = true;
   formSecret = '';
   createdSecret: string | null = null;
@@ -86,7 +92,11 @@ export class WebhooksComponent implements OnInit {
     }
 
     if (this.editingId) {
-      const payload: any = { url: this.formUrl, events, active: this.formActive };
+      const payload: any = {
+        url: this.formUrl,
+        events,
+        active: this.formActive,
+      };
       if (this.formSecret.trim()) payload.secret = this.formSecret;
       this.webhookService.update(this.editingId, payload).subscribe({
         next: () => {

--- a/src/app/view/all-users/all-users.component.ts
+++ b/src/app/view/all-users/all-users.component.ts
@@ -98,8 +98,13 @@ export class AllUsersComponent {
       this.adminService.GetAllOrganization().subscribe((data) => {
         const seen = new Set<string>();
         this.orglist = data.organizations.filter(
-          (org: { api_user_id: string; organizationType: string; name: string }) => {
-            if (org.organizationType === 'Registrant' || seen.has(org.name)) return false;
+          (org: {
+            api_user_id: string;
+            organizationType: string;
+            name: string;
+          }) => {
+            if (org.organizationType === 'Registrant' || seen.has(org.name))
+              return false;
             seen.add(org.name);
             return true;
           },
@@ -166,11 +171,12 @@ export class AllUsersComponent {
       this.dataSource = new MatTableDataSource(this.allUsers);
       return;
     }
-    const filtered = this.allUsers.filter((u: any) =>
-      (u.firstName + ' ' + u.lastName).toLowerCase().includes(term) ||
-      u.email?.toLowerCase().includes(term) ||
-      u.organization?.name?.toLowerCase().includes(term) ||
-      u.role?.toLowerCase().includes(term),
+    const filtered = this.allUsers.filter(
+      (u: any) =>
+        (u.firstName + ' ' + u.lastName).toLowerCase().includes(term) ||
+        u.email?.toLowerCase().includes(term) ||
+        u.organization?.name?.toLowerCase().includes(term) ||
+        u.role?.toLowerCase().includes(term),
     );
     this.dataSource = new MatTableDataSource(filtered);
   }
@@ -199,21 +205,19 @@ export class AllUsersComponent {
     }
   }
   getadminAllUserList(page: number, limit: number) {
-    this.adminService
-      .GetAllUsers(page, limit)
-      .subscribe({
-        next: (data) => {
-          this.showlist = true;
-          this.showorguser = false;
-          this.loading = false;
-          this.allUsers = data.users;
-          this.dataSource = new MatTableDataSource(this.allUsers);
-        },
-        error: (err) => {
-          this.loading = false;
-          this.handleApiError(err);
-        },
-      });
+    this.adminService.GetAllUsers(page, limit).subscribe({
+      next: (data) => {
+        this.showlist = true;
+        this.showorguser = false;
+        this.loading = false;
+        this.allUsers = data.users;
+        this.dataSource = new MatTableDataSource(this.allUsers);
+      },
+      error: (err) => {
+        this.loading = false;
+        this.handleApiError(err);
+      },
+    });
   }
   getOrganizationAllUser(page: number, limit: number) {
     this.orgService.getOrganizationUser(page, limit).subscribe({

--- a/src/app/view/device-groups/device-groups.component.ts
+++ b/src/app/view/device-groups/device-groups.component.ts
@@ -498,14 +498,14 @@ export class DeviceGroups implements OnInit {
   updateReviewStatus(groupId: number, status: string): void {
     this.deviceGroupService.updateGroupReviewStatus(groupId, status).subscribe({
       next: () => {
-        this.toastrService.success(
-          `Group review ${status}`,
-          'Status Updated',
-        );
+        this.toastrService.success(`Group review ${status}`, 'Status Updated');
         this.DisplayList(this.p);
       },
       error: (err: any) => {
-        this.toastrService.error('Update failed', err.error?.message || 'Error');
+        this.toastrService.error(
+          'Update failed',
+          err.error?.message || 'Error',
+        );
       },
     });
   }

--- a/src/app/view/device-reviews/asset-map/asset-map.component.ts
+++ b/src/app/view/device-reviews/asset-map/asset-map.component.ts
@@ -59,7 +59,10 @@ export class AssetMapComponent implements AfterViewInit, OnChanges, OnDestroy {
   private selectedId: string | null = null;
   private selectedSub: Subscription | null = null;
 
-  constructor(private http: HttpClient, private assetService: AssetService) {}
+  constructor(
+    private http: HttpClient,
+    private assetService: AssetService,
+  ) {}
 
   ngAfterViewInit(): void {
     this.map = L.map(this.mapEl.nativeElement, {
@@ -139,7 +142,8 @@ export class AssetMapComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   private panToSelected(id: string): void {
     const asset = this.assets.find((a) => a.id === id);
-    if (!asset || asset.lat === null || asset.long === null || !this.map) return;
+    if (!asset || asset.lat === null || asset.long === null || !this.map)
+      return;
     const currentZoom = this.map.getZoom();
     this.map.flyTo([asset.lat, asset.long], Math.max(currentZoom, 8), {
       duration: 0.6,

--- a/src/app/view/device-reviews/asset.service.ts
+++ b/src/app/view/device-reviews/asset.service.ts
@@ -68,12 +68,17 @@ export class AssetService {
     const existing = current.find((p) => p.url === url);
     if (existing) {
       this.openPictures$.next(
-        current.map((p) => (p.id === existing.id ? { ...p, zOrder: this.nextZOrder() } : p)),
+        current.map((p) =>
+          p.id === existing.id ? { ...p, zOrder: this.nextZOrder() } : p,
+        ),
       );
       return;
     }
     const id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
-    this.openPictures$.next([...current, { id, url, enableOcr, zOrder: this.nextZOrder() }]);
+    this.openPictures$.next([
+      ...current,
+      { id, url, enableOcr, zOrder: this.nextZOrder() },
+    ]);
   }
 
   /** Promote a specific picture to the top of ALL floating windows. */
@@ -82,7 +87,9 @@ export class AssetService {
     const hit = current.find((p) => p.id === id);
     if (!hit) return;
     this.openPictures$.next(
-      current.map((p) => (p.id === id ? { ...p, zOrder: this.nextZOrder() } : p)),
+      current.map((p) =>
+        p.id === id ? { ...p, zOrder: this.nextZOrder() } : p,
+      ),
     );
   }
 
@@ -291,12 +298,13 @@ export class AssetService {
   }
 
   detectPanels(imageBase64: string): Observable<any> {
-    return this.http.post<any>(
-      `${environment.API_URL}device-reviews/detect-panels`,
-      { image: imageBase64 },
-    ).pipe(
-      retry({ count: 2, delay: (err, attempt) => timer(attempt * 3000) }),
-    );
+    return this.http
+      .post<any>(`${environment.API_URL}device-reviews/detect-panels`, {
+        image: imageBase64,
+      })
+      .pipe(
+        retry({ count: 2, delay: (err, attempt) => timer(attempt * 3000) }),
+      );
   }
 
   /** Extract the S3 object key from a presigned URL. */

--- a/src/app/view/device-reviews/device-info-window/device-info-window.component.ts
+++ b/src/app/view/device-reviews/device-info-window/device-info-window.component.ts
@@ -99,7 +99,9 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
     event.preventDefault();
     event.stopPropagation();
     if (!url) {
-      this.toastr.warning('Empty signed URL — backend could not sign (file missing in storage?)');
+      this.toastr.warning(
+        'Empty signed URL — backend could not sign (file missing in storage?)',
+      );
       return;
     }
     if (/\.(jpe?g|png|gif|webp|bmp|svg)/i.test(url)) {
@@ -137,7 +139,10 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
       error: (err) => {
         this.loading = false;
         const msg =
-          err?.error?.message || err?.statusText || err?.message || 'Unknown error';
+          err?.error?.message ||
+          err?.statusText ||
+          err?.message ||
+          'Unknown error';
         this.toastr.error(`Failed to load device details: ${msg}`);
         this.svc.viewDeviceInfo(null);
       },
@@ -196,11 +201,27 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
         fields: [
           { label: '(1) Site Name', value: fmt(d.siteName) },
           { label: '(2) Address', value: fmt(d.address) },
-          { label: '(3) State/Province/County', value: fmt(d.stateProvince) || '—' },
+          {
+            label: '(3) State/Province/County',
+            value: fmt(d.stateProvince) || '—',
+          },
           { label: '(4) Postcode (Zip Code)', value: fmt(d.postcode) || '—' },
-          { label: '(5) Country', value: this.countryNamePipe.transform(d.countryCode) || fmt(d.countryCode) },
-          { label: '(6) Latitude', value: fmt(d.latitude), hint: 'Must provide at least six digits after the decimal; must land exactly on a solar panel' },
-          { label: '(7) Longitude', value: fmt(d.longitude), hint: 'Must provide at least six digits after the decimal; must land exactly on a solar panel' },
+          {
+            label: '(5) Country',
+            value:
+              this.countryNamePipe.transform(d.countryCode) ||
+              fmt(d.countryCode),
+          },
+          {
+            label: '(6) Latitude',
+            value: fmt(d.latitude),
+            hint: 'Must provide at least six digits after the decimal; must land exactly on a solar panel',
+          },
+          {
+            label: '(7) Longitude',
+            value: fmt(d.longitude),
+            hint: 'Must provide at least six digits after the decimal; must land exactly on a solar panel',
+          },
         ],
       },
       {
@@ -208,54 +229,146 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
         fields: [
           { label: '(8) Device Description', value: fmt(d.deviceDescription) },
           { label: '(9) Capacity', value: fmt(d.capacity) },
-          { label: '(10) Commissioning Date', value: fmtDate(d.commissioningDate) },
-          { label: '(11) Requested Effective Reg. Date', value: fmt(d.requestedEffectiveRegDate), hint: 'Please provide the date from which you would like to begin issuing D-RECs for this facility; default is COD.' },
-          { label: '(12) Default Account Code', value: fmt(d.defaultAccountCode), hint: 'Please provide the Evident trade account code you would like this facility to issue into' },
-          { label: '(13) Number of Generating Units', value: fmt(d.generatingUnitCount), hint: 'Please provide the number of devices that output useable electricity at this facility (typically the inverters)' },
+          {
+            label: '(10) Commissioning Date',
+            value: fmtDate(d.commissioningDate),
+          },
+          {
+            label: '(11) Requested Effective Reg. Date',
+            value: fmt(d.requestedEffectiveRegDate),
+            hint: 'Please provide the date from which you would like to begin issuing D-RECs for this facility; default is COD.',
+          },
+          {
+            label: '(12) Default Account Code',
+            value: fmt(d.defaultAccountCode),
+            hint: 'Please provide the Evident trade account code you would like this facility to issue into',
+          },
+          {
+            label: '(13) Number of Generating Units',
+            value: fmt(d.generatingUnitCount),
+            hint: 'Please provide the number of devices that output useable electricity at this facility (typically the inverters)',
+          },
           {
             label: '(14) Meter or Measurement ID(s)',
             value: '',
             items: d.serialNumber
-              ? String(d.serialNumber).split(/\s*;\s*/).filter(Boolean)
+              ? String(d.serialNumber)
+                  .split(/\s*;\s*/)
+                  .filter(Boolean)
               : [],
             hint: 'Serial numbers for all devices from which metering evidence will be shared (e.g. inverters, smart meter, etc.).',
           },
-          { label: '(15) Grid Connected', value: d.gridInterconnection == null ? '—' : d.gridInterconnection ? 'Yes' : 'No' },
+          {
+            label: '(15) Grid Connected',
+            value:
+              d.gridInterconnection == null
+                ? '—'
+                : d.gridInterconnection
+                  ? 'Yes'
+                  : 'No',
+          },
           { label: '(16) Grid Export Type', value: fmt(d.gridExportType) },
-          { label: '(17) Network Owner', value: fmt(d.networkOwner), hint: 'If the facility is grid-connected, please provide the name of the utility or distribution network' },
-          { label: '(18) Interconnection Voltage', value: fmt(d.interconnectionVoltage), hint: 'If the facility is grid-connected, please provide the interconnection voltage' },
+          {
+            label: '(17) Network Owner',
+            value: fmt(d.networkOwner),
+            hint: 'If the facility is grid-connected, please provide the name of the utility or distribution network',
+          },
+          {
+            label: '(18) Interconnection Voltage',
+            value: fmt(d.interconnectionVoltage),
+            hint: 'If the facility is grid-connected, please provide the interconnection voltage',
+          },
           { label: '(19) Network Meter', value: fmt(d.hasNetworkMeter) },
-          { label: '(20) Meter Reads Shareable', value: fmt(d.meterReadsShareable), hint: 'If "yes", this must be provided as sample metering evidence' },
-          { label: '(21) Non-Meter Import Details', value: fmt(d.nonMeterImportDetails) },
-          { label: '(22) Source Access Mode', value: fmt(d.sourceAccessMode), hint: 'Will require paragraph explaining what each mode means' },
+          {
+            label: '(20) Meter Reads Shareable',
+            value: fmt(d.meterReadsShareable),
+            hint: 'If "yes", this must be provided as sample metering evidence',
+          },
+          {
+            label: '(21) Non-Meter Import Details',
+            value: fmt(d.nonMeterImportDetails),
+          },
+          {
+            label: '(22) Source Access Mode',
+            value: fmt(d.sourceAccessMode),
+            hint: 'Will require paragraph explaining what each mode means',
+          },
           { label: '(23) Captive Consumer', value: fmt(d.hasCaptiveConsumer) },
-          { label: '(24) Auxiliary Energy Sources', value: fmt(d.hasAuxiliaryEnergySources), hint: '(typically a backup generator or battery)' },
-          { label: '(25) Auxiliary Source Details', value: fmt(d.auxiliaryEnergySourceDetails), hint: 'Describe the number of units, capacity per unit, and fuel source (e.g. 1 x 250kVA diesel generator)' },
+          {
+            label: '(24) Auxiliary Energy Sources',
+            value: fmt(d.hasAuxiliaryEnergySources),
+            hint: '(typically a backup generator or battery)',
+          },
+          {
+            label: '(25) Auxiliary Source Details',
+            value: fmt(d.auxiliaryEnergySourceDetails),
+            hint: 'Describe the number of units, capacity per unit, and fuel source (e.g. 1 x 250kVA diesel generator)',
+          },
           {
             label: '(26) Submitter Status',
             value:
               d.pvSystemOwner && d.organization?.name
-                ? d.pvSystemOwner.trim().toLowerCase() === d.organization.name.trim().toLowerCase()
+                ? d.pvSystemOwner.trim().toLowerCase() ===
+                  d.organization.name.trim().toLowerCase()
                   ? 'Registrant IS the production-facility owner'
                   : 'Registrant is NOT the production-facility owner'
                 : '—',
             hint: 'Derived by comparing PV System Owner to the registrant organization name',
           },
-          { label: '(27) PV System Owner', value: fmt(d.pvSystemOwner), hint: 'Please provide the legal name of the PV System Owner. This must match the "Proof of Ownership" documentation shared.' },
-          { label: '(28) Off-Taker Name', value: fmt(d.offTakerName), hint: 'Please provide the legal name of the electricity off-taker' },
+          {
+            label: '(27) PV System Owner',
+            value: fmt(d.pvSystemOwner),
+            hint: 'Please provide the legal name of the PV System Owner. This must match the "Proof of Ownership" documentation shared.',
+          },
+          {
+            label: '(28) Off-Taker Name',
+            value: fmt(d.offTakerName),
+            hint: 'Please provide the legal name of the electricity off-taker',
+          },
           { label: '(29) Off Takers', value: fmt(d.offTaker) },
-          { label: '(30) Off-Taker Same as Owner', value: fmt(d.offTakerSameCompanyAsOwner) },
-          { label: '(31) Other EAC Scheme Registration', value: fmt(d.otherEacSchemeRegistration) },
+          {
+            label: '(30) Off-Taker Same as Owner',
+            value: fmt(d.offTakerSameCompanyAsOwner),
+          },
+          {
+            label: '(31) Other EAC Scheme Registration',
+            value: fmt(d.otherEacSchemeRegistration),
+          },
           { label: '(32) Public Funding', value: fmt(d.hasPublicFunding) },
-          { label: '(33) Public Funding End Date', value: fmt(d.publicFundingEndDate) },
+          {
+            label: '(33) Public Funding End Date',
+            value: fmt(d.publicFundingEndDate),
+          },
           { label: '(34) Subsidy Received', value: fmt(d.hasSubsidy) },
           { label: '(35) Subsidy Types', value: fmtArr(d.subsidyTypes) },
-          { label: '(35) Subsidy Other Details', value: fmt(d.subsidyOtherDetails) },
-          { label: '(36) Subsidy Claims EACs', value: fmt(d.subsidyClaimsEacs) },
-          { label: '(37) Labelling Scheme', value: fmt(d.labellingSchemeAccreditation), hint: 'Please choose any other labels for which this site qualifies' },
-          { label: '(38) SDG Benefits', value: fmt(d.SDGBenefits), hint: 'Please choose all applicable UN Sustainable Development Goals that this facility is promoting' },
-          { label: '(39) Impact Story', value: fmt(d.impactStory), hint: 'Please provide a brief description of the social and/or environmental impact being created by this facility' },
-          { label: '(40) Additional Info', value: fmt(d.additionalInfo), hint: 'Please provide any additional information that may be relevant to this facility\'s registration on Evident' },
+          {
+            label: '(35) Subsidy Other Details',
+            value: fmt(d.subsidyOtherDetails),
+          },
+          {
+            label: '(36) Subsidy Claims EACs',
+            value: fmt(d.subsidyClaimsEacs),
+          },
+          {
+            label: '(37) Labelling Scheme',
+            value: fmt(d.labellingSchemeAccreditation),
+            hint: 'Please choose any other labels for which this site qualifies',
+          },
+          {
+            label: '(38) SDG Benefits',
+            value: fmt(d.SDGBenefits),
+            hint: 'Please choose all applicable UN Sustainable Development Goals that this facility is promoting',
+          },
+          {
+            label: '(39) Impact Story',
+            value: fmt(d.impactStory),
+            hint: 'Please provide a brief description of the social and/or environmental impact being created by this facility',
+          },
+          {
+            label: '(40) Additional Info',
+            value: fmt(d.additionalInfo),
+            hint: "Please provide any additional information that may be relevant to this facility's registration on Evident",
+          },
           { label: '(41) Signatory Name', value: fmt(d.signatoryName) },
           {
             label: '(42) Signature',
@@ -269,14 +382,51 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
       {
         heading: 'Documents',
         fields: [
-          { label: '(43) Project Photos', value: fmtDocs('PROJECT_PHOTOS'), links: linksFor('PROJECT_PHOTOS'), hint: 'At least three photos showing the full installation and surrounding topography' },
-          { label: '(44) Facility Boundary', value: fmtDocs('FACILITY_BOUNDARY'), links: linksFor('FACILITY_BOUNDARY'), hint: 'Satellite image with facility boundary outlined' },
-          { label: '(45) Single Line Diagram', value: fmtDocs('SINGLE_LINE_DIAGRAM'), links: linksFor('SINGLE_LINE_DIAGRAM') },
-          { label: '(46) SF-02c (Owner\'s Declaration)', value: fmtDocs('SF_02C'), links: linksFor('SF_02C') },
-          { label: '(47) Proof of Ownership', value: fmtDocs('SF_02C_OWNERS_DECLARATION'), links: linksFor('SF_02C_OWNERS_DECLARATION') },
-          { label: '(48) COD Proof', value: fmtDocs('COD_PROOF'), links: linksFor('COD_PROOF'), hint: 'Handover letter or commissioning certificate confirming the commissioning date' },
-          { label: '(49) Metering Evidence', value: fmtDocs('METERING_EVIDENCE'), links: linksFor('METERING_EVIDENCE'), hint: 'Sample metering evidence relied on for I-REC issuance' },
-          { label: '(50) Other Documents', value: fmtDocs('OTHER_DOCUMENTS'), links: linksFor('OTHER_DOCUMENTS'), hint: 'e.g. No RPO letter for facilities in India' },
+          {
+            label: '(43) Project Photos',
+            value: fmtDocs('PROJECT_PHOTOS'),
+            links: linksFor('PROJECT_PHOTOS'),
+            hint: 'At least three photos showing the full installation and surrounding topography',
+          },
+          {
+            label: '(44) Facility Boundary',
+            value: fmtDocs('FACILITY_BOUNDARY'),
+            links: linksFor('FACILITY_BOUNDARY'),
+            hint: 'Satellite image with facility boundary outlined',
+          },
+          {
+            label: '(45) Single Line Diagram',
+            value: fmtDocs('SINGLE_LINE_DIAGRAM'),
+            links: linksFor('SINGLE_LINE_DIAGRAM'),
+          },
+          {
+            label: "(46) SF-02c (Owner's Declaration)",
+            value: fmtDocs('SF_02C'),
+            links: linksFor('SF_02C'),
+          },
+          {
+            label: '(47) Proof of Ownership',
+            value: fmtDocs('SF_02C_OWNERS_DECLARATION'),
+            links: linksFor('SF_02C_OWNERS_DECLARATION'),
+          },
+          {
+            label: '(48) COD Proof',
+            value: fmtDocs('COD_PROOF'),
+            links: linksFor('COD_PROOF'),
+            hint: 'Handover letter or commissioning certificate confirming the commissioning date',
+          },
+          {
+            label: '(49) Metering Evidence',
+            value: fmtDocs('METERING_EVIDENCE'),
+            links: linksFor('METERING_EVIDENCE'),
+            hint: 'Sample metering evidence relied on for I-REC issuance',
+          },
+          {
+            label: '(50) Other Documents',
+            value: fmtDocs('OTHER_DOCUMENTS'),
+            links: linksFor('OTHER_DOCUMENTS'),
+            hint: 'e.g. No RPO letter for facilities in India',
+          },
         ],
       },
       {
@@ -291,11 +441,20 @@ export class DeviceInfoWindowComponent implements OnInit, OnDestroy {
           { label: 'Other Data Source', value: fmt(d.otherDataSource) },
           { label: 'Data Source Brand', value: fmt(d.dataSourceBrand) },
           { label: 'OnBoarding Date', value: fmtDate(d.createdAt) },
-          { label: 'Operating Configuration', value: fmt(d.operatingConfiguration) },
+          {
+            label: 'Operating Configuration',
+            value: fmt(d.operatingConfiguration),
+          },
           { label: 'Timezone', value: fmt(d.timezone) },
-          { label: 'Ownership Status', value: fmt(d.ownershipStatus || 'unverified') },
+          {
+            label: 'Ownership Status',
+            value: fmt(d.ownershipStatus || 'unverified'),
+          },
           { label: 'Public Funding Type', value: fmt(d.publicFundingType) },
-          { label: 'Off-Grid Circumstances', value: fmt(d.offGridCircumstances) },
+          {
+            label: 'Off-Grid Circumstances',
+            value: fmt(d.offGridCircumstances),
+          },
           { label: 'Version', value: fmt(d.version) },
           { label: 'Yield Value', value: fmt(d.yieldValue) },
           { label: 'Meter Read Type', value: fmt(d.meterReadtype) },

--- a/src/app/view/device-reviews/documents-window/documents-window.component.ts
+++ b/src/app/view/device-reviews/documents-window/documents-window.component.ts
@@ -63,10 +63,20 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   sf02PreviewLoading = false;
   sf02PreviewItem: Asset | null = null;
   sf02PreviewFields: Array<{ label: string; value: string }> = [];
-  sf02PreviewDocs: Array<{ type: string; present: boolean; required: boolean }> = [];
+  sf02PreviewDocs: Array<{
+    type: string;
+    present: boolean;
+    required: boolean;
+  }> = [];
 
   satPreviewEnabled = false;
-  satPreview: { lat: number; lng: number; label: string; x: number; y: number } | null = null;
+  satPreview: {
+    lat: number;
+    lng: number;
+    label: string;
+    x: number;
+    y: number;
+  } | null = null;
 
   statusFilter: Record<AssetStatus, boolean> = this.loadStatusFilter();
   readonly statusFilter$ = new BehaviorSubject(this.statusFilter);
@@ -75,10 +85,20 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
 
   private loadStatusFilter(): Record<AssetStatus, boolean> {
     try {
-      const saved = sessionStorage.getItem(DocumentsWindowComponent.STATUS_FILTER_KEY);
+      const saved = sessionStorage.getItem(
+        DocumentsWindowComponent.STATUS_FILTER_KEY,
+      );
       if (saved) return JSON.parse(saved);
-    } catch { /* ignore */ }
-    return { draft: true, pending: true, approved: false, rejected: false, legacy: false };
+    } catch {
+      /* ignore */
+    }
+    return {
+      draft: true,
+      pending: true,
+      approved: false,
+      rejected: false,
+      legacy: false,
+    };
   }
 
   private saveStatusFilter(): void {
@@ -92,15 +112,32 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   searchIndex = -1;
 
   // sort state
-  sortColumn: 'serial' | 'modifiedDate' | 'status' | 'siteName' | 'countryCode' | 'screenStatus' | 'docs' | 'sf02Ready' =
-    'siteName';
+  sortColumn:
+    | 'serial'
+    | 'modifiedDate'
+    | 'status'
+    | 'siteName'
+    | 'countryCode'
+    | 'screenStatus'
+    | 'docs'
+    | 'sf02Ready' = 'siteName';
   sortDir: 1 | -1 = 1;
   readonly sort$ = new BehaviorSubject<{ col: string; dir: number }>({
     col: 'siteName',
     dir: 1,
   });
 
-  sortBy(col: 'serial' | 'modifiedDate' | 'status' | 'siteName' | 'countryCode' | 'screenStatus' | 'docs' | 'sf02Ready'): void {
+  sortBy(
+    col:
+      | 'serial'
+      | 'modifiedDate'
+      | 'status'
+      | 'siteName'
+      | 'countryCode'
+      | 'screenStatus'
+      | 'docs'
+      | 'sf02Ready',
+  ): void {
     if (this.sortColumn === col) {
       this.sortDir = this.sortDir === 1 ? -1 : 1;
     } else {
@@ -126,11 +163,15 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
         av = a.countryCode.toLowerCase();
         bv = b.countryCode.toLowerCase();
       } else if (this.sortColumn === 'screenStatus') {
-        const rank = (s: string | null) => s === 'fail' ? 0 : s === 'warn' ? 1 : s === 'pass' ? 2 : 3;
+        const rank = (s: string | null) =>
+          s === 'fail' ? 0 : s === 'warn' ? 1 : s === 'pass' ? 2 : 3;
         av = rank(a.lastScreenStatus);
         bv = rank(b.lastScreenStatus);
       } else if (this.sortColumn === 'docs') {
-        const docsOk = (x: Asset) => x.sldUrl && x.sf02Url && x.codProofUrl && x.pictureUrls.length >= 3 ? 1 : 0;
+        const docsOk = (x: Asset) =>
+          x.sldUrl && x.sf02Url && x.codProofUrl && x.pictureUrls.length >= 3
+            ? 1
+            : 0;
         av = docsOk(a);
         bv = docsOk(b);
       } else if (this.sortColumn === 'sf02Ready') {
@@ -151,7 +192,15 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   sectionOpen: Record<
     string,
     Record<
-      'codProof' | 'sld' | 'sf02' | 'sf02c' | 'sf02cOwnersDeclaration' | 'meteringEvidence' | 'pictures' | 'screenshots' | 'otherDocuments',
+      | 'codProof'
+      | 'sld'
+      | 'sf02'
+      | 'sf02c'
+      | 'sf02cOwnersDeclaration'
+      | 'meteringEvidence'
+      | 'pictures'
+      | 'screenshots'
+      | 'otherDocuments',
       boolean
     >
   > = {};
@@ -309,9 +358,19 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
       withinThreshold: boolean | null;
     }>;
     thresholdMeters: number;
-    summary: { total: number; withGps: number; withinThreshold: number; flagged: number };
+    summary: {
+      total: number;
+      withGps: number;
+      withinThreshold: number;
+      flagged: number;
+    };
   } | null = null;
-  private pendingDelete: { asset: Asset; docKey: string; urlField: string; arrayIdx?: number } | null = null;
+  private pendingDelete: {
+    asset: Asset;
+    docKey: string;
+    urlField: string;
+    arrayIdx?: number;
+  } | null = null;
 
   // resizable detail panel
   detailHeight = 280;
@@ -428,7 +487,9 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
           if (asset) this.patchForm(asset);
         }
         this.editingId = id;
-        this.editingSiteName = id ? this.svc.assets$.value.find((a) => a.id === id)?.siteName ?? null : null;
+        this.editingSiteName = id
+          ? this.svc.assets$.value.find((a) => a.id === id)?.siteName ?? null
+          : null;
         this.selId = id;
       }),
     );
@@ -478,10 +539,16 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     // Escape — close topmost modal, or close detail
     if (e.key === 'Escape') {
       if (this.closeTopModal()) return;
-      if (this.editingId) { this.cancelDetail(); return; }
+      if (this.editingId) {
+        this.cancelDetail();
+        return;
+      }
     }
     // Arrow keys — navigate list when no modal is open and not in an input
-    if ((e.key === 'ArrowUp' || e.key === 'ArrowDown') && !this.hasOpenModal()) {
+    if (
+      (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
+      !this.hasOpenModal()
+    ) {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
       e.preventDefault();
@@ -490,20 +557,40 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   }
 
   private hasOpenModal(): boolean {
-    return this.showApproveModal || this.showApprovedInfoModal || this.showDeleteModal
-      || this.showDuplicatesModal || this.showAuditModal || this.showConsistencyModal
-      || this.showCeilingModal || this.showCrossSourceModal || this.showControlsModal
-      || this.showSourceVerifyModal || this.showAutoScreenModal || this.showSldModal
-      || this.showPhotoGpsModal || this.showUnreviewedWarning;
+    return (
+      this.showApproveModal ||
+      this.showApprovedInfoModal ||
+      this.showDeleteModal ||
+      this.showDuplicatesModal ||
+      this.showAuditModal ||
+      this.showConsistencyModal ||
+      this.showCeilingModal ||
+      this.showCrossSourceModal ||
+      this.showControlsModal ||
+      this.showSourceVerifyModal ||
+      this.showAutoScreenModal ||
+      this.showSldModal ||
+      this.showPhotoGpsModal ||
+      this.showUnreviewedWarning
+    );
   }
 
   private closeTopModal(): boolean {
     const modals: (keyof this)[] = [
-      'showApproveModal', 'showApprovedInfoModal', 'showDeleteModal',
-      'showDuplicatesModal', 'showAuditModal', 'showConsistencyModal',
-      'showCeilingModal', 'showCrossSourceModal', 'showControlsModal',
-      'showSourceVerifyModal', 'showAutoScreenModal', 'showSldModal',
-      'showPhotoGpsModal', 'showUnreviewedWarning',
+      'showApproveModal',
+      'showApprovedInfoModal',
+      'showDeleteModal',
+      'showDuplicatesModal',
+      'showAuditModal',
+      'showConsistencyModal',
+      'showCeilingModal',
+      'showCrossSourceModal',
+      'showControlsModal',
+      'showSourceVerifyModal',
+      'showAutoScreenModal',
+      'showSldModal',
+      'showPhotoGpsModal',
+      'showUnreviewedWarning',
     ];
     for (const key of modals) {
       if (this[key]) {
@@ -516,7 +603,11 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
 
   private navigateList(dir: number): void {
     const assets = this.sortAssets(
-      this.applyFilter(this.svc.assets$.value, this.searchTerm, this.statusFilter),
+      this.applyFilter(
+        this.svc.assets$.value,
+        this.searchTerm,
+        this.statusFilter,
+      ),
     );
     if (!assets.length) return;
     const idx = assets.findIndex((a) => a.id === this.editingId);
@@ -747,7 +838,9 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
         this.svc.saveAsset(item);
         this.generatingSf02[item.id] = false;
         this.sf02PreviewItem = null;
-        this.snackBar.open('SF-02 registration form generated', '', { duration: 3000 });
+        this.snackBar.open('SF-02 registration form generated', '', {
+          duration: 3000,
+        });
         this.cdr.markForCheck();
       },
       error: (err) => {
@@ -763,7 +856,7 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   }
 
   get sf02MissingRequired(): boolean {
-    return this.sf02PreviewDocs.some(d => !d.present && d.required);
+    return this.sf02PreviewDocs.some((d) => !d.present && d.required);
   }
 
   cancelSf02Generation(): void {
@@ -773,13 +866,18 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
 
   generateSf02ForSelected(event: Event): void {
     if (!this.editingId) return;
-    const item = this.svc.assets$.value.find(a => a.id === this.editingId);
+    const item = this.svc.assets$.value.find((a) => a.id === this.editingId);
     if (item) this.generateSf02(item, event);
   }
 
   // ── File handling ─────────────────────────────────────────────────────────────
 
-  async openFile(url: string, event: Event, isSld = false, enableOcr = false): Promise<void> {
+  async openFile(
+    url: string,
+    event: Event,
+    isSld = false,
+    enableOcr = false,
+  ): Promise<void> {
     event.stopPropagation();
     if (!url || this.isBroken(url)) {
       alert('File is missing\n\n' + url);
@@ -815,7 +913,11 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
       },
       error: (err) => {
         console.error('Upload failed', err);
-        this.toast('Upload failed — ' + (err?.error?.message || err?.message || 'unknown error'), 5000);
+        this.toast(
+          'Upload failed — ' +
+            (err?.error?.message || err?.message || 'unknown error'),
+          5000,
+        );
       },
     });
   }
@@ -867,7 +969,11 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   }
 
   clearSf02cOwnersDeclaration(asset: Asset): void {
-    this.requestDelete(asset, 'sf02cOwnersDeclaration', 'sf02cOwnersDeclarationUrl');
+    this.requestDelete(
+      asset,
+      'sf02cOwnersDeclaration',
+      'sf02cOwnersDeclarationUrl',
+    );
   }
 
   onOtherDocumentAdd(asset: Asset, event: Event): void {
@@ -887,7 +993,12 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   }
 
   clearMeteringEvidence(asset: Asset, idx: number): void {
-    this.requestDelete(asset, `meteringEvidence:${idx}`, 'meteringEvidenceUrls', idx);
+    this.requestDelete(
+      asset,
+      `meteringEvidence:${idx}`,
+      'meteringEvidenceUrls',
+      idx,
+    );
   }
 
   onPictureAdd(asset: Asset, event: Event): void {
@@ -910,7 +1021,12 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     this.requestDelete(asset, `ss:${idx}`, 'screenshotUrls', idx);
   }
 
-  private requestDelete(asset: Asset, docKey: string, urlField: string, arrayIdx?: number): void {
+  private requestDelete(
+    asset: Asset,
+    docKey: string,
+    urlField: string,
+    arrayIdx?: number,
+  ): void {
     this.pendingDelete = { asset, docKey, urlField, arrayIdx };
     this.showDeleteModal = true;
   }
@@ -957,7 +1073,8 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   fileDisplayName(asset: Asset, docKey: string, url: string): string {
     const meta = asset.docMeta?.[docKey];
     if (meta?.label && meta.label.trim() !== '') return meta.label;
-    if (meta?.originalFilename && meta.originalFilename.trim() !== '') return meta.originalFilename;
+    if (meta?.originalFilename && meta.originalFilename.trim() !== '')
+      return meta.originalFilename;
     return this.fileName(url);
   }
 
@@ -989,28 +1106,127 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     }
   }
 
-  private readonly displayNames = new Intl.DisplayNames(['en'], { type: 'region' });
+  private readonly displayNames = new Intl.DisplayNames(['en'], {
+    type: 'region',
+  });
   private readonly alpha3to2: Record<string, string> = {
-    IND: 'IN', USA: 'US', GBR: 'GB', DEU: 'DE', FRA: 'FR', BRA: 'BR', CHN: 'CN', JPN: 'JP',
-    KEN: 'KE', NGA: 'NG', ZAF: 'ZA', AUS: 'AU', CAN: 'CA', MEX: 'MX', IDN: 'ID', PAK: 'PK',
-    BGD: 'BD', NPL: 'NP', LKA: 'LK', THA: 'TH', VNM: 'VN', PHL: 'PH', MYS: 'MY', SGP: 'SG',
-    ETH: 'ET', TZA: 'TZ', UGA: 'UG', RWA: 'RW', GHA: 'GH', SEN: 'SN', CMR: 'CM', MOZ: 'MZ',
-    MDG: 'MG', MWI: 'MW', ZMB: 'ZM', ZWE: 'ZW', NLD: 'NL', ESP: 'ES', ITA: 'IT', PRT: 'PT',
-    SWE: 'SE', NOR: 'NO', DNK: 'DK', FIN: 'FI', CHE: 'CH', AUT: 'AT', BEL: 'BE', POL: 'PL',
-    ROU: 'RO', HUN: 'HU', CZE: 'CZ', BGR: 'BG', HRV: 'HR', SRB: 'RS', TUR: 'TR', EGY: 'EG',
-    MAR: 'MA', TUN: 'TN', DZA: 'DZ', SAU: 'SA', ARE: 'AE', QAT: 'QA', KWT: 'KW', OMN: 'OM',
-    IRQ: 'IQ', IRN: 'IR', AFG: 'AF', COL: 'CO', PER: 'PE', CHL: 'CL', ARG: 'AR', BOL: 'BO',
-    PRY: 'PY', URY: 'UY', ECU: 'EC', VEN: 'VE', CRI: 'CR', PAN: 'PA', GTM: 'GT', HND: 'HN',
-    SLV: 'SV', NIC: 'NI', DOM: 'DO', HTI: 'HT', JAM: 'JM', NZL: 'NZ', FJI: 'FJ', PNG: 'PG',
-    SOM: 'SO', SSD: 'SS', SDN: 'SD', MLI: 'ML', NER: 'NE', BFA: 'BF', TCD: 'TD', CAF: 'CF',
-    COD: 'CD', COG: 'CG', AGO: 'AO', NAM: 'NA', BWA: 'BW', LSO: 'LS', SWZ: 'SZ',
+    IND: 'IN',
+    USA: 'US',
+    GBR: 'GB',
+    DEU: 'DE',
+    FRA: 'FR',
+    BRA: 'BR',
+    CHN: 'CN',
+    JPN: 'JP',
+    KEN: 'KE',
+    NGA: 'NG',
+    ZAF: 'ZA',
+    AUS: 'AU',
+    CAN: 'CA',
+    MEX: 'MX',
+    IDN: 'ID',
+    PAK: 'PK',
+    BGD: 'BD',
+    NPL: 'NP',
+    LKA: 'LK',
+    THA: 'TH',
+    VNM: 'VN',
+    PHL: 'PH',
+    MYS: 'MY',
+    SGP: 'SG',
+    ETH: 'ET',
+    TZA: 'TZ',
+    UGA: 'UG',
+    RWA: 'RW',
+    GHA: 'GH',
+    SEN: 'SN',
+    CMR: 'CM',
+    MOZ: 'MZ',
+    MDG: 'MG',
+    MWI: 'MW',
+    ZMB: 'ZM',
+    ZWE: 'ZW',
+    NLD: 'NL',
+    ESP: 'ES',
+    ITA: 'IT',
+    PRT: 'PT',
+    SWE: 'SE',
+    NOR: 'NO',
+    DNK: 'DK',
+    FIN: 'FI',
+    CHE: 'CH',
+    AUT: 'AT',
+    BEL: 'BE',
+    POL: 'PL',
+    ROU: 'RO',
+    HUN: 'HU',
+    CZE: 'CZ',
+    BGR: 'BG',
+    HRV: 'HR',
+    SRB: 'RS',
+    TUR: 'TR',
+    EGY: 'EG',
+    MAR: 'MA',
+    TUN: 'TN',
+    DZA: 'DZ',
+    SAU: 'SA',
+    ARE: 'AE',
+    QAT: 'QA',
+    KWT: 'KW',
+    OMN: 'OM',
+    IRQ: 'IQ',
+    IRN: 'IR',
+    AFG: 'AF',
+    COL: 'CO',
+    PER: 'PE',
+    CHL: 'CL',
+    ARG: 'AR',
+    BOL: 'BO',
+    PRY: 'PY',
+    URY: 'UY',
+    ECU: 'EC',
+    VEN: 'VE',
+    CRI: 'CR',
+    PAN: 'PA',
+    GTM: 'GT',
+    HND: 'HN',
+    SLV: 'SV',
+    NIC: 'NI',
+    DOM: 'DO',
+    HTI: 'HT',
+    JAM: 'JM',
+    NZL: 'NZ',
+    FJI: 'FJ',
+    PNG: 'PG',
+    SOM: 'SO',
+    SSD: 'SS',
+    SDN: 'SD',
+    MLI: 'ML',
+    NER: 'NE',
+    BFA: 'BF',
+    TCD: 'TD',
+    CAF: 'CF',
+    COD: 'CD',
+    COG: 'CG',
+    AGO: 'AO',
+    NAM: 'NA',
+    BWA: 'BW',
+    LSO: 'LS',
+    SWZ: 'SZ',
   };
 
   countryName(code: string): string {
     if (!code) return '';
-    const a2 = code.length === 3 ? this.alpha3to2[code.toUpperCase()] : code.toUpperCase();
+    const a2 =
+      code.length === 3
+        ? this.alpha3to2[code.toUpperCase()]
+        : code.toUpperCase();
     if (!a2) return code;
-    try { return this.displayNames.of(a2) ?? code; } catch { return code; }
+    try {
+      return this.displayNames.of(a2) ?? code;
+    } catch {
+      return code;
+    }
   }
 
   // ── URL validation ──────────────────────────────────────────────────────────
@@ -1059,7 +1275,9 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
           ctx.drawImage(img, 0, 0, c.width, c.height);
           const data = ctx.getImageData(0, 0, c.width, c.height).data;
           // Check if every pixel is the same (solid color = likely placeholder)
-          const r0 = data[0], g0 = data[1], b0 = data[2];
+          const r0 = data[0],
+            g0 = data[1],
+            b0 = data[2];
           let allSame = true;
           for (let i = 4; i < data.length; i += 4) {
             if (data[i] !== r0 || data[i + 1] !== g0 || data[i + 2] !== b0) {
@@ -1103,7 +1321,8 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
 
   /** Get requirement level for a document type based on the device's operating config. */
   getReqLevel(docType: string, config?: string | null): RequirementLevel | '' {
-    const c = config ?? this.detailForm?.get('operatingConfiguration')?.value ?? null;
+    const c =
+      config ?? this.detailForm?.get('operatingConfiguration')?.value ?? null;
     if (!c) return '';
     const reqs = getEvidenceRequirements(c);
     return (reqs as any)[docType] ?? 'required';
@@ -1114,7 +1333,11 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
    * and whether the document is present. Returns 'satisfied' if present, or the
    * requirement level if missing.
    */
-  getReqStatus(docType: string, config: string | null, hasDoc: boolean): string {
+  getReqStatus(
+    docType: string,
+    config: string | null,
+    hasDoc: boolean,
+  ): string {
     if (!config) return '';
     const level = this.getReqLevel(docType, config);
     if (!level) return '';
@@ -1124,7 +1347,8 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
 
   /** Get config-specific hint for a document type. */
   getDocHint(docType: string, config?: string | null): string | null {
-    const c = config ?? this.detailForm?.get('operatingConfiguration')?.value ?? null;
+    const c =
+      config ?? this.detailForm?.get('operatingConfiguration')?.value ?? null;
     return getHint(c, docType);
   }
 
@@ -1212,9 +1436,7 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     }
 
     // Otherwise look up/create a conversation for the site
-    const asset = this.svc.assets$.value.find(
-      (a) => a.siteName === siteName,
-    );
+    const asset = this.svc.assets$.value.find((a) => a.siteName === siteName);
     const submitterEmail = asset?.submitterEmail || '';
 
     this.chatService.getConversation(undefined, undefined, siteName).subscribe({
@@ -1293,11 +1515,17 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
         this.duplicateResults = res.duplicates || [];
         this.showDuplicatesModal = true;
         if (this.duplicateResults.length > 0) {
-          const asset = this.svc.assets$.value.find((a) => a.id === this.editingId);
+          const asset = this.svc.assets$.value.find(
+            (a) => a.id === this.editingId,
+          );
           if (asset) {
-            const matches = this.duplicateResults.map((d: any) => d.matchType).join(', ');
-            this.logChatEntry(asset.siteName,
-              `_Duplicate screening flagged ${this.duplicateResults.length} potential match(es): ${matches}. Please review and clarify._`);
+            const matches = this.duplicateResults
+              .map((d: any) => d.matchType)
+              .join(', ');
+            this.logChatEntry(
+              asset.siteName,
+              `_Duplicate screening flagged ${this.duplicateResults.length} potential match(es): ${matches}. Please review and clarify._`,
+            );
           }
         }
       },
@@ -1343,7 +1571,13 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     const text = this.auditTrail
       .map((e) => {
         const date = new Date(e.createdAt);
-        const ts = date.toLocaleString('en-GB', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+        const ts = date.toLocaleString('en-GB', {
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        });
         let line = `${e.actionType}  ${e.performedBy}  ${ts}`;
         if (e.detail) line += `\n  ${e.detail}`;
         return line;
@@ -1359,8 +1593,19 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     const escape = (v: string) => `"${(v || '').replace(/"/g, '""')}"`;
     const header = 'Action,Performed By,Date,Detail';
     const rows = this.filteredAuditTrail.map((e: any) => {
-      const ts = new Date(e.createdAt).toLocaleString('en-GB', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
-      return [escape(e.actionType), escape(e.performedBy), escape(ts), escape(e.detail || '')].join(',');
+      const ts = new Date(e.createdAt).toLocaleString('en-GB', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      return [
+        escape(e.actionType),
+        escape(e.performedBy),
+        escape(ts),
+        escape(e.detail || ''),
+      ].join(',');
     });
     const csv = [header, ...rows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -1403,10 +1648,14 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
         this.ceilingError = null;
         this.showCeilingModal = true;
         if (res.yieldMismatch) {
-          const asset = this.svc.assets$.value.find((a) => a.id === this.editingId);
+          const asset = this.svc.assets$.value.find(
+            (a) => a.id === this.editingId,
+          );
           if (asset) {
-            this.logChatEntry(asset.siteName,
-              `_Production ceiling check: configured yield (${res.configuredYield} kWh/kW/yr) exceeds the location-based estimate (${res.irradiance?.yieldHigh} kWh/kW/yr). Please verify or correct the yield value._`);
+            this.logChatEntry(
+              asset.siteName,
+              `_Production ceiling check: configured yield (${res.configuredYield} kWh/kW/yr) exceeds the location-based estimate (${res.irradiance?.yieldHigh} kWh/kW/yr). Please verify or correct the yield value._`,
+            );
           }
         }
       },
@@ -1414,7 +1663,9 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
         console.error('Production ceiling check failed:', err);
         this.ceilingResult = null;
         this.ceilingError =
-          err?.error?.message || err?.message || 'Unknown error — check the browser console for details.';
+          err?.error?.message ||
+          err?.message ||
+          'Unknown error — check the browser console for details.';
         this.showCeilingModal = true;
       },
     });
@@ -1434,7 +1685,9 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
         console.error('Source-access verification failed:', err);
         this.sourceVerifyResult = null;
         this.sourceVerifyError =
-          err?.error?.message || err?.message || 'Unknown error — check the browser console for details.';
+          err?.error?.message ||
+          err?.message ||
+          'Unknown error — check the browser console for details.';
         this.showSourceVerifyModal = true;
       },
     });
@@ -1485,7 +1738,10 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
       setTimeout(() => (this.autoScreenCopied = false), 1500);
     };
     if (navigator.clipboard?.writeText) {
-      navigator.clipboard.writeText(text).then(done).catch(() => this.fallbackCopy(text, done));
+      navigator.clipboard
+        .writeText(text)
+        .then(done)
+        .catch(() => this.fallbackCopy(text, done));
     } else {
       this.fallbackCopy(text, done);
     }
@@ -1498,7 +1754,12 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     ta.style.opacity = '0';
     document.body.appendChild(ta);
     ta.select();
-    try { document.execCommand('copy'); done(); } finally { document.body.removeChild(ta); }
+    try {
+      document.execCommand('copy');
+      done();
+    } finally {
+      document.body.removeChild(ta);
+    }
   }
 
   runAutoScreen(): void {
@@ -1514,7 +1775,9 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
         this.autoScreenResult = res;
         this.autoScreenLoading = false;
         // Update the badge on the asset list immediately
-        const asset = this.svc.assets$.value.find((a) => a.id === this.editingId);
+        const asset = this.svc.assets$.value.find(
+          (a) => a.id === this.editingId,
+        );
         if (asset) {
           asset.lastScreenStatus = res.overallStatus;
           asset.lastScreenedAt = res.timestamp;
@@ -1523,7 +1786,10 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
       error: (err: any) => {
         console.error('Auto-screen failed:', err);
         this.autoScreenResult = null;
-        this.autoScreenError = err?.error?.message || err?.message || 'Unknown error — check the browser console for details.';
+        this.autoScreenError =
+          err?.error?.message ||
+          err?.message ||
+          'Unknown error — check the browser console for details.';
         this.autoScreenLoading = false;
       },
     });
@@ -1690,7 +1956,8 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     };
     const parts = key.split(':');
     if (parts[1] === 'pic') return `Picture #${parseInt(parts[2], 10) + 1}`;
-    if (parts[1] === 'otherDoc') return `Other Document #${parseInt(parts[2], 10) + 1}`;
+    if (parts[1] === 'otherDoc')
+      return `Other Document #${parseInt(parts[2], 10) + 1}`;
     return labels[parts[1]] || parts[1];
   }
 
@@ -1721,7 +1988,10 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     const gap = 16;
     const rightFits = event.clientX + gap + boxW < window.innerWidth;
     const x = rightFits ? event.clientX + gap : event.clientX - gap - boxW;
-    const y = Math.min(Math.max(event.clientY - boxH / 2, 4), window.innerHeight - boxH - 4);
+    const y = Math.min(
+      Math.max(event.clientY - boxH / 2, 4),
+      window.innerHeight - boxH - 4,
+    );
     return { x, y };
   }
 
@@ -1748,9 +2018,7 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
     }
 
     // Look up the device to get submitter email for conversation creation
-    const asset = this.svc.assets$.value.find(
-      (a) => a.siteName === siteName,
-    );
+    const asset = this.svc.assets$.value.find((a) => a.siteName === siteName);
     const submitterEmail = asset?.submitterEmail || '';
 
     this.chatService.getConversation(undefined, undefined, siteName).subscribe({
@@ -1886,7 +2154,9 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   }
 
   bulkSetStatus(status: string): void {
-    const ids = this.checkedIds.map((id) => parseInt(id, 10)).filter((n) => !isNaN(n));
+    const ids = this.checkedIds
+      .map((id) => parseInt(id, 10))
+      .filter((n) => !isNaN(n));
     if (!ids.length) return;
     if (!confirm(`Set ${ids.length} device(s) to "${status}"?`)) return;
     this.bulkBusy = true;
@@ -1894,7 +2164,9 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
       next: () => {
         // Update local state
         const assets = this.svc.assets$.value.map((a) =>
-          this.checked[a.id] ? { ...a, status: status as AssetStatus, modifiedDate: new Date() } : a,
+          this.checked[a.id]
+            ? { ...a, status: status as AssetStatus, modifiedDate: new Date() }
+            : a,
         );
         this.svc.assets$.next(assets);
         this.checked = {};
@@ -1910,15 +2182,20 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   }
 
   bulkScreen(): void {
-    const ids = this.checkedIds.map((id) => parseInt(id, 10)).filter((n) => !isNaN(n));
+    const ids = this.checkedIds
+      .map((id) => parseInt(id, 10))
+      .filter((n) => !isNaN(n));
     if (!ids.length) return;
-    if (!confirm(`Auto-screen ${ids.length} device(s)? This may take a while.`)) return;
+    if (!confirm(`Auto-screen ${ids.length} device(s)? This may take a while.`))
+      return;
     this.bulkBusy = true;
     this.svc.bulkAutoScreen(ids).subscribe({
       next: (results: any[]) => {
         // Update badges
         for (const r of results) {
-          const asset = this.svc.assets$.value.find((a) => a.id === String(r.deviceId));
+          const asset = this.svc.assets$.value.find(
+            (a) => a.id === String(r.deviceId),
+          );
           if (asset) {
             asset.lastScreenStatus = r.overallStatus ?? r.error ? 'fail' : null;
             asset.lastScreenedAt = r.timestamp ?? new Date().toISOString();
@@ -1927,7 +2204,9 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
         this.checked = {};
         this.bulkBusy = false;
         this.cdr.markForCheck();
-        const passed = results.filter((r: any) => r.overallStatus === 'pass').length;
+        const passed = results.filter(
+          (r: any) => r.overallStatus === 'pass',
+        ).length;
         this.toast(`Screened ${results.length} device(s) — ${passed} passed`);
       },
       error: (err: any) => {
@@ -1939,20 +2218,30 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   }
 
   screenAllUnscreened(): void {
-    if (!confirm('Auto-screen all unscreened pending devices (up to 50)? This may take a while.')) return;
+    if (
+      !confirm(
+        'Auto-screen all unscreened pending devices (up to 50)? This may take a while.',
+      )
+    )
+      return;
     this.bulkBusy = true;
     this.svc.bulkAutoScreen().subscribe({
       next: (results: any[]) => {
         for (const r of results) {
-          const asset = this.svc.assets$.value.find((a) => a.id === String(r.deviceId));
+          const asset = this.svc.assets$.value.find(
+            (a) => a.id === String(r.deviceId),
+          );
           if (asset) {
-            asset.lastScreenStatus = r.overallStatus ?? (r.error ? 'fail' : null);
+            asset.lastScreenStatus =
+              r.overallStatus ?? (r.error ? 'fail' : null);
             asset.lastScreenedAt = r.timestamp ?? new Date().toISOString();
           }
         }
         this.bulkBusy = false;
         this.cdr.markForCheck();
-        const passed = results.filter((r: any) => r.overallStatus === 'pass').length;
+        const passed = results.filter(
+          (r: any) => r.overallStatus === 'pass',
+        ).length;
         this.toast(`Screened ${results.length} device(s) — ${passed} passed`);
       },
       error: (err: any) => {
@@ -1966,39 +2255,54 @@ export class DocumentsWindowComponent implements OnInit, OnDestroy {
   exportExcel(): void {
     import('xlsx').then((XLSX) => {
       const assets = this.sortAssets(
-        this.applyFilter(this.svc.assets$.value, this.searchTerm, this.statusFilter),
+        this.applyFilter(
+          this.svc.assets$.value,
+          this.searchTerm,
+          this.statusFilter,
+        ),
       );
       const rows = assets.map((a) => ({
         'Site Name': a.siteName,
-        'Status': a.status,
+        Status: a.status,
         'Screen Result': a.lastScreenStatus || '',
-        'Screened At': a.lastScreenedAt ? new Date(a.lastScreenedAt).toLocaleDateString('en-GB') : '',
-        'Reviewer': a.reviewer || '',
-        'Submitter': a.submitterEmail || '',
-        'Country': a.countryCode || '',
+        'Screened At': a.lastScreenedAt
+          ? new Date(a.lastScreenedAt).toLocaleDateString('en-GB')
+          : '',
+        Reviewer: a.reviewer || '',
+        Submitter: a.submitterEmail || '',
+        Country: a.countryCode || '',
         'Capacity (kW)': a.capacity ?? '',
-        'Latitude': a.lat ?? '',
-        'Longitude': a.long ?? '',
-        'Date Added': a.dateAdded ? a.dateAdded.toLocaleDateString('en-GB') : '',
-        'Date Submitted': a.dateSubmitted ? a.dateSubmitted.toLocaleDateString('en-GB') : '',
-        'Modified': a.modifiedDate ? a.modifiedDate.toLocaleDateString('en-GB') : '',
-        'Config': a.operatingConfiguration || '',
-        'Pathway': a.evidencePathway || '',
-        'Notes': a.notes || '',
-        'SLD': a.sldUrl ? 'Yes' : '',
+        Latitude: a.lat ?? '',
+        Longitude: a.long ?? '',
+        'Date Added': a.dateAdded
+          ? a.dateAdded.toLocaleDateString('en-GB')
+          : '',
+        'Date Submitted': a.dateSubmitted
+          ? a.dateSubmitted.toLocaleDateString('en-GB')
+          : '',
+        Modified: a.modifiedDate
+          ? a.modifiedDate.toLocaleDateString('en-GB')
+          : '',
+        Config: a.operatingConfiguration || '',
+        Pathway: a.evidencePathway || '',
+        Notes: a.notes || '',
+        SLD: a.sldUrl ? 'Yes' : '',
         'SF-02': a.sf02Url ? 'Yes' : '',
         'SF-02C': a.sf02cUrl ? 'Yes' : '',
         "Owner's Declaration": a.sf02cOwnersDeclarationUrl ? 'Yes' : '',
         'COD Proof': a.codProofUrl ? 'Yes' : '',
         'Metering Evidence': a.meteringEvidenceUrls.length || '',
-        'Pictures': a.pictureUrls.length || '',
-        'Screenshots': a.screenshotUrls.length || '',
+        Pictures: a.pictureUrls.length || '',
+        Screenshots: a.screenshotUrls.length || '',
         'Other Documents': a.otherDocumentUrls.length || '',
       }));
       const ws = XLSX.utils.json_to_sheet(rows);
       // Auto-width columns
       const colWidths = Object.keys(rows[0] || {}).map((key) => ({
-        wch: Math.max(key.length, ...rows.map((r) => String((r as any)[key] ?? '').length)).valueOf(),
+        wch: Math.max(
+          key.length,
+          ...rows.map((r) => String((r as any)[key] ?? '').length),
+        ).valueOf(),
       }));
       ws['!cols'] = colWidths;
       const wb = XLSX.utils.book_new();

--- a/src/app/view/device-reviews/floating-window/floating-window.component.ts
+++ b/src/app/view/device-reviews/floating-window/floating-window.component.ts
@@ -19,7 +19,9 @@ import {
   styleUrls: ['./floating-window.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FloatingWindowComponent implements OnInit, AfterViewInit, OnDestroy {
+export class FloatingWindowComponent
+  implements OnInit, AfterViewInit, OnDestroy
+{
   @Input() title = '';
   @Input() initX = 20;
   @Input() initY = 20;
@@ -105,8 +107,14 @@ export class FloatingWindowComponent implements OnInit, AfterViewInit, OnDestroy
       if (this.x < -(this.width - 80)) this.x = -(this.width - 80);
       this.cdr.markForCheck();
     } else if (this.resizing) {
-      this.width = Math.max(260, this.resizeStartW + (event.clientX - this.resizeStartX));
-      this.height = Math.max(140, this.resizeStartH + (event.clientY - this.resizeStartY));
+      this.width = Math.max(
+        260,
+        this.resizeStartW + (event.clientX - this.resizeStartX),
+      );
+      this.height = Math.max(
+        140,
+        this.resizeStartH + (event.clientY - this.resizeStartY),
+      );
       this.cdr.markForCheck();
     }
   }

--- a/src/app/view/device-reviews/pdf-window/pdf-window.component.ts
+++ b/src/app/view/device-reviews/pdf-window/pdf-window.component.ts
@@ -50,8 +50,12 @@ export class PdfWindowComponent implements OnInit, OnDestroy {
       this.safeUrl = null;
       this.currentUrl = url;
       this.fileName = url
-        ? decodeURIComponent(url.split('?')[0].split('/').pop() || 'Document Viewer')
-            .replace(/-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=\.[^.]+$)/i, '')
+        ? decodeURIComponent(
+            url.split('?')[0].split('/').pop() || 'Document Viewer',
+          ).replace(
+            /-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=\.[^.]+$)/i,
+            '',
+          )
         : 'Document Viewer';
 
       if (url) {
@@ -75,7 +79,9 @@ export class PdfWindowComponent implements OnInit, OnDestroy {
       // Force application/pdf MIME type to ensure iframe renders it
       const blob = new Blob([arrayBuffer], { type: 'application/pdf' });
       this.blobUrl = URL.createObjectURL(blob);
-      this.safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(this.blobUrl);
+      this.safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
+        this.blobUrl,
+      );
     } catch {
       this.safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(url);
     }

--- a/src/app/view/device-reviews/picture-window/picture-window.component.ts
+++ b/src/app/view/device-reviews/picture-window/picture-window.component.ts
@@ -106,8 +106,10 @@ export class PictureWindowComponent implements OnInit {
   highlightOcr(text: string, term: string): string {
     if (!term) return text.replace(/&/g, '&amp;').replace(/</g, '&lt;');
     const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;');
-    const termEscaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      .replace(/&/g, '&amp;').replace(/</g, '&lt;');
+    const termEscaped = term
+      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;');
     return escaped.replace(
       new RegExp(termEscaped, 'gi'),
       (m) => `<mark>${m}</mark>`,
@@ -182,7 +184,9 @@ export class PictureWindowComponent implements OnInit {
     for (let i = this.predictions.length - 1; i >= 0; i--) {
       if (this.hitTest(this.predictions[i], x, y)) {
         if (this.selectedRegion === i) {
-          this.predictions = this.predictions.filter((_: any, j: number) => j !== i);
+          this.predictions = this.predictions.filter(
+            (_: any, j: number) => j !== i,
+          );
           this.selectedRegion = -1;
           this.panelCount = this.predictions.length;
           const ctx = canvas.getContext('2d')!;
@@ -208,7 +212,11 @@ export class PictureWindowComponent implements OnInit {
   }
 
   deleteSelected(): void {
-    if (this.selectedRegion < 0 || this.selectedRegion >= this.predictions.length) return;
+    if (
+      this.selectedRegion < 0 ||
+      this.selectedRegion >= this.predictions.length
+    )
+      return;
     this.predictions.splice(this.selectedRegion, 1);
     this.selectedRegion = -1;
     this.panelCount = this.predictions.length;
@@ -219,12 +227,20 @@ export class PictureWindowComponent implements OnInit {
     const points: { x: number; y: number }[] = pred.points ?? [];
     if (points.length > 2) {
       // Point-in-polygon (ray-casting)
-      const scaled = points.map(p => ({ x: p.x * this.scaleX, y: p.y * this.scaleY }));
+      const scaled = points.map((p) => ({
+        x: p.x * this.scaleX,
+        y: p.y * this.scaleY,
+      }));
       let inside = false;
       for (let i = 0, j = scaled.length - 1; i < scaled.length; j = i++) {
-        const xi = scaled[i].x, yi = scaled[i].y;
-        const xj = scaled[j].x, yj = scaled[j].y;
-        if (((yi > my) !== (yj > my)) && (mx < (xj - xi) * (my - yi) / (yj - yi) + xi)) {
+        const xi = scaled[i].x,
+          yi = scaled[i].y;
+        const xj = scaled[j].x,
+          yj = scaled[j].y;
+        if (
+          yi > my !== yj > my &&
+          mx < ((xj - xi) * (my - yi)) / (yj - yi) + xi
+        ) {
           inside = !inside;
         }
       }
@@ -246,7 +262,9 @@ export class PictureWindowComponent implements OnInit {
     for (let i = 0; i < this.predictions.length; i++) {
       const pred = this.predictions[i];
       const selected = i === this.selectedRegion;
-      const fill = selected ? 'rgba(239, 68, 68, 0.4)' : 'rgba(0, 255, 180, 0.3)';
+      const fill = selected
+        ? 'rgba(239, 68, 68, 0.4)'
+        : 'rgba(0, 255, 180, 0.3)';
       const stroke = selected ? '#ef4444' : '#00ffb4';
       const points: { x: number; y: number }[] = pred.points ?? [];
 
@@ -279,8 +297,8 @@ export class PictureWindowComponent implements OnInit {
         let dotX: number, dotY: number;
         if (points.length > 2) {
           // Find top-right of bounding box
-          const xs = points.map(p => p.x * this.scaleX);
-          const ys = points.map(p => p.y * this.scaleY);
+          const xs = points.map((p) => p.x * this.scaleX);
+          const ys = points.map((p) => p.y * this.scaleY);
           dotX = Math.max(...xs);
           dotY = Math.min(...ys);
         } else {
@@ -316,7 +334,10 @@ export class PictureWindowComponent implements OnInit {
 
     const canvas = document.createElement('canvas');
     const maxDim = 640;
-    const scale = Math.min(1, maxDim / Math.max(img.naturalWidth, img.naturalHeight));
+    const scale = Math.min(
+      1,
+      maxDim / Math.max(img.naturalWidth, img.naturalHeight),
+    );
     canvas.width = Math.round(img.naturalWidth * scale);
     canvas.height = Math.round(img.naturalHeight * scale);
     const ctx = canvas.getContext('2d')!;
@@ -352,7 +373,9 @@ export class PictureWindowComponent implements OnInit {
       const scale = Math.min(1, maxDim / Math.max(bmp.width, bmp.height));
       canvas.width = Math.round(bmp.width * scale);
       canvas.height = Math.round(bmp.height * scale);
-      canvas.getContext('2d')!.drawImage(bmp, 0, 0, canvas.width, canvas.height);
+      canvas
+        .getContext('2d')!
+        .drawImage(bmp, 0, 0, canvas.width, canvas.height);
       bmp.close();
 
       const base64 = canvas.toDataURL('image/jpeg', 0.6).split(',')[1];

--- a/src/app/view/device-reviews/satellite-window/satellite-window.component.ts
+++ b/src/app/view/device-reviews/satellite-window/satellite-window.component.ts
@@ -77,20 +77,40 @@ const STATUS_COLOR: Record<string, string> = {
             ✕ Remove Region
           </button>
           <span class="detect-count" *ngIf="panelCount > 0"
-            >{{ panelCount }} region{{ panelCount === 1 ? '' : 's' }}
+            >{{ panelCount }} region{{
+              panelCount === 1 ? '' : 's'
+            }}
             found</span
           >
-          <span class="detect-error" *ngIf="detectError">{{ detectError }}</span>
+          <span class="detect-error" *ngIf="detectError">{{
+            detectError
+          }}</span>
         </div>
         <div class="sat-date" *ngIf="satelliteDate">
           🛰 Latest imagery: {{ satelliteDate }}
         </div>
-        <div class="detect-confirm-backdrop" *ngIf="showDetectConfirm" (click)="cancelDetect()">
+        <div
+          class="detect-confirm-backdrop"
+          *ngIf="showDetectConfirm"
+          (click)="cancelDetect()"
+        >
           <div class="detect-confirm" (click)="$event.stopPropagation()">
             <p class="detect-confirm__msg">{{ detectConfirmMsg }}</p>
             <div class="detect-confirm__actions">
-              <button type="button" class="detect-confirm__btn detect-confirm__btn--cancel" (click)="cancelDetect()">Cancel</button>
-              <button type="button" class="detect-confirm__btn detect-confirm__btn--ok" (click)="confirmDetect()">OK</button>
+              <button
+                type="button"
+                class="detect-confirm__btn detect-confirm__btn--cancel"
+                (click)="cancelDetect()"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="detect-confirm__btn detect-confirm__btn--ok"
+                (click)="confirmDetect()"
+              >
+                OK
+              </button>
             </div>
           </div>
         </div>
@@ -438,7 +458,11 @@ export class SatelliteWindowComponent
   }
 
   deleteSelected(): void {
-    if (this.selectedRegion < 0 || this.selectedRegion >= this.predictions.length) return;
+    if (
+      this.selectedRegion < 0 ||
+      this.selectedRegion >= this.predictions.length
+    )
+      return;
     this.predictions.splice(this.selectedRegion, 1);
     this.selectedRegion = -1;
     this.panelCount = this.predictions.length;
@@ -449,15 +473,20 @@ export class SatelliteWindowComponent
   private satHitTest(pred: any, mx: number, my: number): boolean {
     const points: { x: number; y: number }[] = pred.points ?? [];
     if (points.length > 2) {
-      const scaled = points.map(p => ({
+      const scaled = points.map((p) => ({
         x: p.x * this.satScaleX + this.satCropX,
         y: p.y * this.satScaleY + this.satCropY,
       }));
       let inside = false;
       for (let i = 0, j = scaled.length - 1; i < scaled.length; j = i++) {
-        const xi = scaled[i].x, yi = scaled[i].y;
-        const xj = scaled[j].x, yj = scaled[j].y;
-        if (((yi > my) !== (yj > my)) && (mx < (xj - xi) * (my - yi) / (yj - yi) + xi)) {
+        const xi = scaled[i].x,
+          yi = scaled[i].y;
+        const xj = scaled[j].x,
+          yj = scaled[j].y;
+        if (
+          yi > my !== yj > my &&
+          mx < ((xj - xi) * (my - yi)) / (yj - yi) + xi
+        ) {
           inside = !inside;
         }
       }
@@ -478,15 +507,23 @@ export class SatelliteWindowComponent
     for (let i = 0; i < this.predictions.length; i++) {
       const pred = this.predictions[i];
       const selected = i === this.selectedRegion;
-      const fill = selected ? 'rgba(239, 68, 68, 0.4)' : 'rgba(0, 255, 180, 0.3)';
+      const fill = selected
+        ? 'rgba(239, 68, 68, 0.4)'
+        : 'rgba(0, 255, 180, 0.3)';
       const stroke = selected ? '#ef4444' : '#00ffb4';
       const points: { x: number; y: number }[] = pred.points ?? [];
 
       if (points.length > 2) {
         ctx.beginPath();
-        ctx.moveTo(points[0].x * this.satScaleX + this.satCropX, points[0].y * this.satScaleY + this.satCropY);
+        ctx.moveTo(
+          points[0].x * this.satScaleX + this.satCropX,
+          points[0].y * this.satScaleY + this.satCropY,
+        );
         for (let j = 1; j < points.length; j++) {
-          ctx.lineTo(points[j].x * this.satScaleX + this.satCropX, points[j].y * this.satScaleY + this.satCropY);
+          ctx.lineTo(
+            points[j].x * this.satScaleX + this.satCropX,
+            points[j].y * this.satScaleY + this.satCropY,
+          );
         }
         ctx.closePath();
         ctx.fillStyle = fill;
@@ -510,8 +547,8 @@ export class SatelliteWindowComponent
       if (selected) {
         let dotX: number, dotY: number;
         if (points.length > 2) {
-          const xs = points.map(p => p.x * this.satScaleX + this.satCropX);
-          const ys = points.map(p => p.y * this.satScaleY + this.satCropY);
+          const xs = points.map((p) => p.x * this.satScaleX + this.satCropX);
+          const ys = points.map((p) => p.y * this.satScaleY + this.satCropY);
           dotX = Math.max(...xs);
           dotY = Math.min(...ys);
         } else {
@@ -595,9 +632,17 @@ export class SatelliteWindowComponent
 
     // Verify canvas isn't blank
     const sample = srcCtx.getImageData(
-      Math.floor(w / 2), Math.floor(h / 2), 1, 1,
+      Math.floor(w / 2),
+      Math.floor(h / 2),
+      1,
+      1,
     ).data;
-    if (sample[0] === 0 && sample[1] === 0 && sample[2] === 0 && sample[3] === 0) {
+    if (
+      sample[0] === 0 &&
+      sample[1] === 0 &&
+      sample[2] === 0 &&
+      sample[3] === 0
+    ) {
       this.detecting = false;
       this.detectError = 'Could not capture map tiles (CORS)';
       this.cdr.markForCheck();
@@ -616,16 +661,26 @@ export class SatelliteWindowComponent
     const scale = Math.min(1, maxDim / Math.max(cropW, cropH));
     cropCanvas.width = Math.round(cropW * scale);
     cropCanvas.height = Math.round(cropH * scale);
-    cropCanvas.getContext('2d')!.drawImage(
-      srcCanvas, cropX, cropY, cropW, cropH,
-      0, 0, cropCanvas.width, cropCanvas.height,
-    );
+    cropCanvas
+      .getContext('2d')!
+      .drawImage(
+        srcCanvas,
+        cropX,
+        cropY,
+        cropW,
+        cropH,
+        0,
+        0,
+        cropCanvas.width,
+        cropCanvas.height,
+      );
 
     const base64 = cropCanvas.toDataURL('image/jpeg', 0.85).split(',')[1];
 
     // Call backend proxy (keeps Roboflow API key server-side)
     this.svc.detectPanels(base64).subscribe({
-      next: (data) => this.drawDetections(data, w, h, cropX, cropY, cropW, cropH),
+      next: (data) =>
+        this.drawDetections(data, w, h, cropX, cropY, cropW, cropH),
       error: (err) => {
         this.detectError =
           'Detection failed: ' + (err?.error?.message || err?.message || err);
@@ -636,8 +691,13 @@ export class SatelliteWindowComponent
   }
 
   private drawDetections(
-    data: any, w: number, h: number,
-    cropX: number, cropY: number, cropW: number, cropH: number,
+    data: any,
+    w: number,
+    h: number,
+    cropX: number,
+    cropY: number,
+    cropW: number,
+    cropH: number,
   ): void {
     const canvas = this.overlayCanvas.nativeElement;
     canvas.width = w;
@@ -689,10 +749,16 @@ export class SatelliteWindowComponent
         .on('mouseover', () => {
           this.removePinOverlay();
           this.pinOverlay = SatellitePreviewComponent.createOverlay(
-            asset.siteName, lat, lng, this.http,
+            asset.siteName,
+            lat,
+            lng,
+            this.http,
           );
           SatellitePreviewComponent.positionOverlay(
-            this.pinOverlay, this.map!, lat, lng,
+            this.pinOverlay,
+            this.map!,
+            lat,
+            lng,
           );
         })
         .on('mouseout', () => this.removePinOverlay())

--- a/src/app/view/device/add-bulk-device/add-bulk-device.component.ts
+++ b/src/app/view/device/add-bulk-device/add-bulk-device.component.ts
@@ -200,7 +200,8 @@ export class AddBulkDeviceComponent implements OnInit {
           this.uploading = false;
           clearInterval(this.uploadTimer);
           const msg = err?.error?.message ?? err?.message ?? 'Unknown error';
-          this.lastError = err?.error?.statusCode === 403 ? 'You are Unauthorized' : msg;
+          this.lastError =
+            err?.error?.statusCode === 403 ? 'You are Unauthorized' : msg;
           this.toastrService.error(this.lastError!, 'Upload failed');
         },
       });
@@ -237,7 +238,10 @@ export class AddBulkDeviceComponent implements OnInit {
               );
               this.openPreview(job.id, job.organizationId);
             } else {
-              this.toastrService.error('Processing finished with errors', 'Failed');
+              this.toastrService.error(
+                'Processing finished with errors',
+                'Failed',
+              );
             }
           }
         });
@@ -280,30 +284,35 @@ export class AddBulkDeviceComponent implements OnInit {
     if (this.refreshing) return;
     this.showBulkUploadLogs = false;
     this.refreshing = true;
-    this.bulkUploadService
-      .getBulkUploads(BulkUploadType.Devices)
-      .subscribe({
-        next: (data) => {
-          this.refreshing = false;
-          this.data = data;
-          this.dataSource = new MatTableDataSource(this.data.bulkUploadJobs);
-          this.dataSource.sort = this.sort;
-        },
-        error: (err) => {
-          this.refreshing = false;
-          this.toastrService.error(
-            err?.error?.message ?? err?.message ?? 'Failed to load jobs',
-            'Refresh failed',
-          );
-        },
-      });
+    this.bulkUploadService.getBulkUploads(BulkUploadType.Devices).subscribe({
+      next: (data) => {
+        this.refreshing = false;
+        this.data = data;
+        this.dataSource = new MatTableDataSource(this.data.bulkUploadJobs);
+        this.dataSource.sort = this.sort;
+      },
+      error: (err) => {
+        this.refreshing = false;
+        this.toastrService.error(
+          err?.error?.message ?? err?.message ?? 'Failed to load jobs',
+          'Refresh failed',
+        );
+      },
+    });
   }
   // Preview (two-stage bulk upload) state
   showPreview: boolean = false;
   previewBulkUploadId: string | null = null;
   previewRecords: any[] = [];
   previewDataSource: MatTableDataSource<any>;
-  previewColumns = ['row', 'siteName', 'serialNumber', 'capacity', 'countryCode', 'commissioningDate'];
+  previewColumns = [
+    'row',
+    'siteName',
+    'serialNumber',
+    'capacity',
+    'countryCode',
+    'commissioningDate',
+  ];
   previewBusy: boolean = false;
   previewTotalCsvRows: number = 0;
   previewSkippedRows: number = 0;
@@ -363,7 +372,8 @@ export class AddBulkDeviceComponent implements OnInit {
 
   discardPreview() {
     if (!this.previewBulkUploadId || this.previewBusy) return;
-    if (!confirm('Discard this upload? The parsed rows will be thrown away.')) return;
+    if (!confirm('Discard this upload? The parsed rows will be thrown away.'))
+      return;
     this.previewBusy = true;
     this.bulkUploadService
       .discardBulkUpload(this.previewBulkUploadId)

--- a/src/app/view/device/add-devices/add-devices.component.ts
+++ b/src/app/view/device/add-devices/add-devices.component.ts
@@ -24,7 +24,13 @@ import {
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { Observable, Subscription, Subject } from 'rxjs';
-import { startWith, map, debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import {
+  startWith,
+  map,
+  debounceTime,
+  distinctUntilChanged,
+  switchMap,
+} from 'rxjs/operators';
 import {
   OrganizationInformation,
   fulecodeType,
@@ -383,13 +389,15 @@ export class AddDevicesComponent implements OnDestroy {
 
     device.get('latitude')?.valueChanges.subscribe((v: any) => {
       const stripped = typeof v === 'string' ? v.replace(/\s/g, '') : v;
-      if (stripped !== v) device.get('latitude')?.setValue(stripped, { emitEvent: false });
+      if (stripped !== v)
+        device.get('latitude')?.setValue(stripped, { emitEvent: false });
       const longitude = device.get('longitude')?.value;
       this.updateMapMarkers(stripped, longitude);
     });
     device.get('longitude')?.valueChanges.subscribe((v: any) => {
       const stripped = typeof v === 'string' ? v.replace(/\s/g, '') : v;
-      if (stripped !== v) device.get('longitude')?.setValue(stripped, { emitEvent: false });
+      if (stripped !== v)
+        device.get('longitude')?.setValue(stripped, { emitEvent: false });
       const latitude = device.get('latitude')?.value;
       this.updateMapMarkers(latitude, stripped);
     });
@@ -536,19 +544,22 @@ export class AddDevicesComponent implements OnDestroy {
   }
 
   private setupSiteNameWatcher(deviceGroup: FormGroup, index: number) {
-    deviceGroup.get('siteName')?.valueChanges.pipe(
-      debounceTime(400),
-      distinctUntilChanged(),
-      switchMap((name: string) => {
-        if (!name || name.trim().length < 2) {
-          this.siteNameExists[index] = false;
-          return [];
-        }
-        return this.deviceService.checkSiteName(name.trim());
-      }),
-    ).subscribe((res) => {
-      this.siteNameExists[index] = res?.exists ?? false;
-    });
+    deviceGroup
+      .get('siteName')
+      ?.valueChanges.pipe(
+        debounceTime(400),
+        distinctUntilChanged(),
+        switchMap((name: string) => {
+          if (!name || name.trim().length < 2) {
+            this.siteNameExists[index] = false;
+            return [];
+          }
+          return this.deviceService.checkSiteName(name.trim());
+        }),
+      )
+      .subscribe((res) => {
+        this.siteNameExists[index] = res?.exists ?? false;
+      });
   }
 
   private setupDataSourceWatcher(deviceGroup: FormGroup) {
@@ -692,8 +703,9 @@ export class AddDevicesComponent implements OnDestroy {
 
   checkDocumentsUploaded() {
     const noFiles = Object.keys(this.files).length === 0;
-    const allDocsUploaded = !noFiles && this.deviceForms.controls.every(
-      (group, deviceIndex) => {
+    const allDocsUploaded =
+      !noFiles &&
+      this.deviceForms.controls.every((group, deviceIndex) => {
         if (!this.files[deviceIndex]) return false;
         return this.requiredFileTypes.every((fileType) => {
           // SF-02 not required when self-declaration mode is selected (platform generates it)
@@ -705,8 +717,7 @@ export class AddDevicesComponent implements OnDestroy {
           }
           return this.files[deviceIndex][fileType]?.length > 0;
         });
-      },
-    );
+      });
 
     this.allDocumentsUploaded = allDocsUploaded;
     // Partial submit allowed: docs just influence the warning banner, not formValid
@@ -729,7 +740,11 @@ export class AddDevicesComponent implements OnDestroy {
       );
     }
 
-    const multiTypes: string[] = ['PROJECT_PHOTOS', 'METERING_EVIDENCE', 'OTHER_DOCUMENTS'];
+    const multiTypes: string[] = [
+      'PROJECT_PHOTOS',
+      'METERING_EVIDENCE',
+      'OTHER_DOCUMENTS',
+    ];
     const prevLen = (this.files[deviceIndex][fileType] || []).length;
     if (multiTypes.includes(fileType)) {
       this.files[deviceIndex][fileType] = [
@@ -752,7 +767,9 @@ export class AddDevicesComponent implements OnDestroy {
 
     const fileControl = this.deviceForms.at(deviceIndex).get(fileType);
     if (fileControl) {
-      fileControl.setValue(this.files[deviceIndex][fileType][0] ?? input.files[0]);
+      fileControl.setValue(
+        this.files[deviceIndex][fileType][0] ?? input.files[0],
+      );
       fileControl.markAsDirty();
     }
 
@@ -790,10 +807,17 @@ export class AddDevicesComponent implements OnDestroy {
 
   renameableTypes: string[] = ['PROJECT_PHOTOS', 'METERING_EVIDENCE'];
 
-  renameDialogFiles: { file: File; url: string; name: string; type: 'image' | 'pdf' | 'excel' | 'other'; label: string }[] = [];
+  renameDialogFiles: {
+    file: File;
+    url: string;
+    name: string;
+    type: 'image' | 'pdf' | 'excel' | 'other';
+    label: string;
+  }[] = [];
 
   openRenameDialog(deviceIndex: number, fileType: string): void {
-    const files = this.files[deviceIndex]?.[fileType as keyof DeviceFiles] || [];
+    const files =
+      this.files[deviceIndex]?.[fileType as keyof DeviceFiles] || [];
     if (!files.length) return;
     // Revoke any URLs from a prior opening before creating new ones.
     for (const u of this.renameObjectUrls) URL.revokeObjectURL(u);
@@ -808,11 +832,21 @@ export class AddDevicesComponent implements OnDestroy {
       const url = URL.createObjectURL(f);
       this.renameObjectUrls.push(url);
       const ext = (f.name.split('.').pop() || '').toLowerCase();
-      const type: 'image' | 'pdf' | 'excel' | 'other' =
-        ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'].includes(ext) ? 'image'
-        : ext === 'pdf' ? 'pdf'
-        : ext === 'xlsx' || ext === 'xls' ? 'excel'
-        : 'other';
+      const type: 'image' | 'pdf' | 'excel' | 'other' = [
+        'jpg',
+        'jpeg',
+        'png',
+        'gif',
+        'webp',
+        'bmp',
+        'svg',
+      ].includes(ext)
+        ? 'image'
+        : ext === 'pdf'
+          ? 'pdf'
+          : ext === 'xlsx' || ext === 'xls'
+            ? 'excel'
+            : 'other';
       return {
         file: f,
         url,
@@ -837,7 +871,8 @@ export class AddDevicesComponent implements OnDestroy {
 
   saveRenameDialog(): void {
     const labels = this.renameDialogFiles.map((r) => r.label || '');
-    this.fileLabels[this.renameDialogDeviceIndex][this.renameDialogType] = labels;
+    this.fileLabels[this.renameDialogDeviceIndex][this.renameDialogType] =
+      labels;
     this.renameDialogRef?.close();
   }
 
@@ -849,7 +884,12 @@ export class AddDevicesComponent implements OnDestroy {
     return (name.split('.').pop() || '').toUpperCase();
   }
 
-  openRenamePreview(r: { url: string; name: string; type: 'image' | 'pdf' | 'excel' | 'other'; file: File }): void {
+  openRenamePreview(r: {
+    url: string;
+    name: string;
+    type: 'image' | 'pdf' | 'excel' | 'other';
+    file: File;
+  }): void {
     if (r.type === 'image') {
       this.imageFullViewUrl = r.url;
       this.imageFullViewName = r.name;
@@ -887,23 +927,31 @@ export class AddDevicesComponent implements OnDestroy {
     this.deviceService.getDocuments(deviceId).subscribe({
       next: (docs) => {
         for (const type of this.renameableTypes) {
-          const files = this.files[deviceIndex]?.[type as keyof DeviceFiles] || [];
+          const files =
+            this.files[deviceIndex]?.[type as keyof DeviceFiles] || [];
           const labels = labelsByType[type] || [];
           for (let i = 0; i < files.length; i++) {
             const label = (labels[i] || '').trim();
             if (!label) continue;
             const match = docs.find(
-              (d) => d.type === type && d.originalFilename === files[i].name && !d.label,
+              (d) =>
+                d.type === type &&
+                d.originalFilename === files[i].name &&
+                !d.label,
             );
             if (!match) continue;
             this.deviceService.updateDocumentLabel(match.id, label).subscribe({
               error: (err) =>
-                console.warn(`Failed to save label for ${files[i].name}`, err?.message),
+                console.warn(
+                  `Failed to save label for ${files[i].name}`,
+                  err?.message,
+                ),
             });
           }
         }
       },
-      error: (err) => console.warn('Failed to fetch documents for labeling', err?.message),
+      error: (err) =>
+        console.warn('Failed to fetch documents for labeling', err?.message),
     });
   }
 
@@ -934,7 +982,9 @@ export class AddDevicesComponent implements OnDestroy {
       }
       if (element.longitude) {
         const [intLng, decLng] = String(element.longitude).split('.');
-        element.longitude = decLng ? `${intLng}.${decLng.slice(0, 20)}` : intLng;
+        element.longitude = decLng
+          ? `${intLng}.${decLng.slice(0, 20)}`
+          : intLng;
       }
 
       // OC#37 is a multi-select in the UI but stored as a '; '-joined string
@@ -1025,7 +1075,9 @@ export class AddDevicesComponent implements OnDestroy {
         return;
       }
 
-      const sf02Mode = this.deviceForms.at(index)?.get('sf02EvidenceMode')?.value;
+      const sf02Mode = this.deviceForms
+        .at(index)
+        ?.get('sf02EvidenceMode')?.value;
 
       this.deviceService.create(formData).subscribe({
         next: (result: any) => {
@@ -1041,13 +1093,20 @@ export class AddDevicesComponent implements OnDestroy {
 
           // Auto-generate SF-02 registration form when self-declaration mode is selected
           if (sf02Mode === 'self' && result?.id) {
-            this.http.post(
-              `${environment.API_URL}device-reviews/${result.id}/generate-sf02`,
-              {},
-            ).subscribe({
-              next: () => this.toastrService.info('SF-02 registration form generated', 'SF-02'),
-              error: (err) => console.warn('SF-02 generation failed:', err?.message),
-            });
+            this.http
+              .post(
+                `${environment.API_URL}device-reviews/${result.id}/generate-sf02`,
+                {},
+              )
+              .subscribe({
+                next: () =>
+                  this.toastrService.info(
+                    'SF-02 registration form generated',
+                    'SF-02',
+                  ),
+                error: (err) =>
+                  console.warn('SF-02 generation failed:', err?.message),
+              });
           }
 
           const idx = deviceArray.indexOf(element);
@@ -1115,7 +1174,10 @@ export class AddDevicesComponent implements OnDestroy {
   private savedCoords: { lat: string; lng: string } | null = null;
   private coordDeviceIndex = 0;
 
-  onMapCenterChanged(center: { lat: number; lng: number }, deviceIndex: number): void {
+  onMapCenterChanged(
+    center: { lat: number; lng: number },
+    deviceIndex: number,
+  ): void {
     if (this.mapCenterUpdating) return;
     this.mapCenterUpdating = true;
     const group = this.deviceForms.at(deviceIndex);
@@ -1139,7 +1201,10 @@ export class AddDevicesComponent implements OnDestroy {
 
   onCoordPaste(event: ClipboardEvent, deviceIndex: number): void {
     const text = event.clipboardData?.getData('text') ?? '';
-    const parts = text.split(/\t+/).map((s) => s.trim()).filter(Boolean);
+    const parts = text
+      .split(/\t+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
     if (parts.length !== 2) return;
     if (isNaN(parseFloat(parts[0])) || isNaN(parseFloat(parts[1]))) return;
     event.preventDefault();
@@ -1156,8 +1221,12 @@ export class AddDevicesComponent implements OnDestroy {
     if (!this.savedCoords) return;
     const group = this.deviceForms.at(this.coordDeviceIndex);
     if (group) {
-      group.get('latitude')?.setValue(this.savedCoords.lat, { emitEvent: false });
-      group.get('longitude')?.setValue(this.savedCoords.lng, { emitEvent: false });
+      group
+        .get('latitude')
+        ?.setValue(this.savedCoords.lat, { emitEvent: false });
+      group
+        .get('longitude')
+        ?.setValue(this.savedCoords.lng, { emitEvent: false });
       const lat = parseFloat(this.savedCoords.lat);
       const lng = parseFloat(this.savedCoords.lng);
       if (!isNaN(lat) && !isNaN(lng)) {
@@ -1190,7 +1259,9 @@ export class AddDevicesComponent implements OnDestroy {
     }
     this.files[deviceIndex][DocumentType.METERING_EVIDENCE].push(file);
 
-    const fileControl = this.deviceForms.at(deviceIndex).get('METERING_EVIDENCE');
+    const fileControl = this.deviceForms
+      .at(deviceIndex)
+      .get('METERING_EVIDENCE');
     if (fileControl) {
       fileControl.setValue(file);
       fileControl.markAsDirty();
@@ -1207,7 +1278,10 @@ export class AddDevicesComponent implements OnDestroy {
       name: file.name,
     };
 
-    this.toastrService.success(`Map capture "${file.name}" added as metering evidence`, 'Captured');
+    this.toastrService.success(
+      `Map capture "${file.name}" added as metering evidence`,
+      'Captured',
+    );
   }
 
   updateMapMarkers(latitude: any, longitude: any) {
@@ -1234,5 +1308,4 @@ export class AddDevicesComponent implements OnDestroy {
       }
     }
   }
-
 }

--- a/src/app/view/device/alldevices/alldevices.component.ts
+++ b/src/app/view/device/alldevices/alldevices.component.ts
@@ -21,7 +21,11 @@ import { MatButtonModule } from '@angular/material/button';
 import { DeviceDetailsComponent } from '../device-details/device-details.component';
 import { ToastrService } from 'ngx-toastr';
 import { fulecodeType, devicecodeType, CountryInfo } from '../../../models';
-import { MapComponent, satellitePreview, SatellitePreview } from '../../map/map.component';
+import {
+  MapComponent,
+  satellitePreview,
+  SatellitePreview,
+} from '../../map/map.component';
 import { ChatService } from '../../../chat/chat.service';
 import { environment } from '../../../../environments/environment';
 
@@ -58,7 +62,13 @@ export class AlldevicesComponent {
   dataSource: MatTableDataSource<any>;
   data: any;
   searchText: string = '';
-  satPreview: { lat: number; lng: number; label: string; x: number; y: number } | null = null;
+  satPreview: {
+    lat: number;
+    lng: number;
+    label: string;
+    x: number;
+    y: number;
+  } | null = null;
   satPreviewEnabled = false;
   loginuser: any;
   deviceurl: any;
@@ -168,9 +178,15 @@ export class AlldevicesComponent {
     });
 
     forkJoin({
-      fuel: this.authService.GetMethod('device/fuel-type').pipe(catchError(() => of([]))),
-      deviceType: this.authService.GetMethod('device/device-type').pipe(catchError(() => of([]))),
-      country: this.authService.GetMethod('countrycode/list').pipe(catchError(() => of([]))),
+      fuel: this.authService
+        .GetMethod('device/fuel-type')
+        .pipe(catchError(() => of([]))),
+      deviceType: this.authService
+        .GetMethod('device/device-type')
+        .pipe(catchError(() => of([]))),
+      country: this.authService
+        .GetMethod('countrycode/list')
+        .pipe(catchError(() => of([]))),
     }).subscribe(({ fuel, deviceType, country }) => {
       this.fuellist = fuel as any;
       this.fuellistLoaded = true;
@@ -400,7 +416,9 @@ export class AlldevicesComponent {
             );
           } else {
             this.toastrService.error(
-              err.error?.message || err.message || 'An unexpected error occurred',
+              err.error?.message ||
+                err.message ||
+                'An unexpected error occurred',
               'Error',
             );
           }
@@ -495,7 +513,9 @@ export class AlldevicesComponent {
       data: {
         title: 'Are you sure? This cannot be undone.',
         message:
-          'Are you sure you want to delete device ' + device.serialNumber + '? This action cannot be undone.',
+          'Are you sure you want to delete device ' +
+          device.serialNumber +
+          '? This action cannot be undone.',
       },
     });
     confirmDialog.afterClosed().subscribe((result) => {
@@ -547,8 +567,18 @@ export class AlldevicesComponent {
       this.bulkDeleting = true;
       const calls = rows.map((r) =>
         this.deviceService.RemoveDevice(r.id).pipe(
-          map((resp) => ({ ok: !!resp?.success, id: r.id, msg: resp?.message })),
-          catchError((err) => of({ ok: false, id: r.id, msg: err?.error?.message ?? err?.message ?? 'error' })),
+          map((resp) => ({
+            ok: !!resp?.success,
+            id: r.id,
+            msg: resp?.message,
+          })),
+          catchError((err) =>
+            of({
+              ok: false,
+              id: r.id,
+              msg: err?.error?.message ?? err?.message ?? 'error',
+            }),
+          ),
         ),
       );
       forkJoin(calls).subscribe((results) => {
@@ -556,7 +586,10 @@ export class AlldevicesComponent {
         const ok = results.filter((r: any) => r.ok).length;
         const failed = results.length - ok;
         if (ok > 0) {
-          this.toastrService.success(`Deleted ${ok} device${ok === 1 ? '' : 's'}`, 'Bulk delete');
+          this.toastrService.success(
+            `Deleted ${ok} device${ok === 1 ? '' : 's'}`,
+            'Bulk delete',
+          );
         }
         if (failed > 0) {
           this.toastrService.warning(
@@ -684,7 +717,10 @@ export class AlldevicesComponent {
     const gap = 16;
     const rightFits = event.clientX + gap + boxW < window.innerWidth;
     const x = rightFits ? event.clientX + gap : event.clientX - gap - boxW;
-    const y = Math.min(Math.max(event.clientY - boxH / 2, 4), window.innerHeight - boxH - 4);
+    const y = Math.min(
+      Math.max(event.clientY - boxH / 2, 4),
+      window.innerHeight - boxH - 4,
+    );
     return { x, y };
   }
 

--- a/src/app/view/device/device-details/device-details.component.ts
+++ b/src/app/view/device/device-details/device-details.component.ts
@@ -76,7 +76,10 @@ export class DeviceDetailsComponent {
           this.loading = false;
           this.device_details = device;
           this.documents = documents ?? [];
-          console.log('[device-details] documents loaded for id=' + this.id + ':', this.documents);
+          console.log(
+            '[device-details] documents loaded for id=' + this.id + ':',
+            this.documents,
+          );
           this.name = this.device_details.externalId;
 
           this.device_details['fuelname'] = this.fuellist.find(
@@ -112,13 +115,19 @@ export class DeviceDetailsComponent {
     return this.documents.filter((d) => d.type === type);
   }
 
-  docLinkLabel(d: { label: string | null; originalFilename: string | null; id: number }): string {
+  docLinkLabel(d: {
+    label: string | null;
+    originalFilename: string | null;
+    id: number;
+  }): string {
     return d.label || d.originalFilename || `File ${d.id}`;
   }
 
   splitSerials(joined: string | null | undefined): string[] {
     if (!joined) return [];
-    return String(joined).split(/\s*;\s*/).filter(Boolean);
+    return String(joined)
+      .split(/\s*;\s*/)
+      .filter(Boolean);
   }
 
   /**
@@ -133,7 +142,9 @@ export class DeviceDetailsComponent {
     event.stopPropagation();
     const cached = this.documents.find((d) => d.id === docId);
     if (!cached?.url) {
-      this.toastrService.warning('Signed URL unavailable — try reopening the dialog');
+      this.toastrService.warning(
+        'Signed URL unavailable — try reopening the dialog',
+      );
       return;
     }
     window.open(cached.url, '_blank', 'noopener');

--- a/src/app/view/device/edit-device/edit-device.component.ts
+++ b/src/app/view/device/edit-device/edit-device.component.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit, OnDestroy, ViewChild, TemplateRef } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  ViewChild,
+  TemplateRef,
+} from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { MatDialog } from '@angular/material/dialog';
 import {
@@ -16,7 +22,15 @@ import { map, startWith } from 'rxjs/operators';
 import { CountryInfo, fulecodeType, devicecodeType } from '../../../models';
 import { postcodeValidator } from '../../../utils/validate-postcode';
 import { MapComponent } from '../../map/map.component';
-import { DocumentType, LABELLING_SCHEMES, OperatingConfiguration, PublicFundingType, RegistrationType, SourceAccessMode, VolumeEvidenceType } from '../../../utils/drec.enum';
+import {
+  DocumentType,
+  LABELLING_SCHEMES,
+  OperatingConfiguration,
+  PublicFundingType,
+  RegistrationType,
+  SourceAccessMode,
+  VolumeEvidenceType,
+} from '../../../utils/drec.enum';
 import {
   getEvidenceRequirements,
   getHint,
@@ -109,7 +123,13 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
   // Document upload support
   DocumentType = DocumentType;
   files: { [key: string]: File[] } = {};
-  filePreviews: { [key: string]: { url: SafeResourceUrl; type: 'image' | 'pdf' | 'excel' | 'other'; name: string } } = {};
+  filePreviews: {
+    [key: string]: {
+      url: SafeResourceUrl;
+      type: 'image' | 'pdf' | 'excel' | 'other';
+      name: string;
+    };
+  } = {};
   existingDocs: {
     [type: string]: {
       url: string;
@@ -133,7 +153,7 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
       'The capacity (in MW) matches the installed Alternating Current (AC) capacity shown on the Single Line Diagram (SLD) and supporting documents.',
       'The effective date of registration matches the date inputted on the Registry. It must not be before the effective date of registration set out by the Residual Mix Deadline.',
       'The number of generating units (generators) is provided and matches the amount in the supporting SLD.',
-      'The serial numbers of the facility\'s meters are provided.',
+      "The serial numbers of the facility's meters are provided.",
     ],
     SF_02C: [], // radio selection handled separately
     METERING_EVIDENCE: [
@@ -159,7 +179,9 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
   sf02cType: 'declaration' | 'ownership' | null = null;
 
   initChecklists(): void {
-    for (const [docType, items] of Object.entries(EditDeviceComponent.DOC_CHECKLISTS)) {
+    for (const [docType, items] of Object.entries(
+      EditDeviceComponent.DOC_CHECKLISTS,
+    )) {
       this.checklistState[docType] = new Array(items.length).fill(false);
     }
   }
@@ -185,7 +207,9 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
     const arr = this.getSerialNumbers();
     arr[index] = value;
     const joined = arr.filter((s) => s !== '').join(';');
-    this.updateDeviceForm.get('serialNumber')?.setValue(joined || null, { emitEvent: false });
+    this.updateDeviceForm
+      .get('serialNumber')
+      ?.setValue(joined || null, { emitEvent: false });
     this.updateDeviceForm.get('serialNumber')?.markAsDirty();
   }
 
@@ -193,12 +217,16 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
     const arr = this.getSerialNumbers();
     arr.push('');
     const joined = arr.filter((s) => s !== '').join(';');
-    this.updateDeviceForm.get('serialNumber')?.setValue(joined || null, { emitEvent: false });
+    this.updateDeviceForm
+      .get('serialNumber')
+      ?.setValue(joined || null, { emitEvent: false });
     // Force the *ngFor to see the new empty slot by re-reading through the
     // form control value — since we don't push '', we need a sentinel:
     // push a trailing ';' so split yields an extra empty entry.
     const cur = this.updateDeviceForm.get('serialNumber')?.value ?? '';
-    this.updateDeviceForm.get('serialNumber')?.setValue(cur + (cur ? ';' : ''), { emitEvent: false });
+    this.updateDeviceForm
+      .get('serialNumber')
+      ?.setValue(cur + (cur ? ';' : ''), { emitEvent: false });
     // Move focus to the newly-added input after Angular renders it
     setTimeout(() => {
       const list = document.querySelector('.serial-list');
@@ -212,7 +240,9 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
     if (arr.length <= 1) return;
     arr.splice(index, 1);
     const joined = arr.filter((s) => s !== '').join(';');
-    this.updateDeviceForm.get('serialNumber')?.setValue(joined || null, { emitEvent: false });
+    this.updateDeviceForm
+      .get('serialNumber')
+      ?.setValue(joined || null, { emitEvent: false });
     this.updateDeviceForm.get('serialNumber')?.markAsDirty();
   }
 
@@ -229,7 +259,10 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
 
   saveRenameDialog(): void {
     const docs = this.existingDocs[this.renameDialogType] || [];
-    const changed: { entry: typeof docs[number]; normalized: string | null }[] = [];
+    const changed: {
+      entry: (typeof docs)[number];
+      normalized: string | null;
+    }[] = [];
     for (let i = 0; i < docs.length; i++) {
       const trimmed = (this.renameDialogDraft[i] ?? '').trim();
       const normalized = trimmed === '' ? null : trimmed;
@@ -387,22 +420,24 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
     this.showaddmore = true;
     this.shownomore = false;
     this.updateDeviceForm.valueChanges.subscribe();
-    this.updateDeviceForm
-      .get('latitude')
-      ?.valueChanges.subscribe((v) => {
-        const stripped = typeof v === 'string' ? v.replace(/\s/g, '') : v;
-        if (stripped !== v) this.updateDeviceForm.get('latitude')?.setValue(stripped, { emitEvent: false });
-        const longitude = this.updateDeviceForm.get('longitude')?.value;
-        this.updateMapMarkers(stripped, longitude);
-      });
-    this.updateDeviceForm
-      .get('longitude')
-      ?.valueChanges.subscribe((v) => {
-        const stripped = typeof v === 'string' ? v.replace(/\s/g, '') : v;
-        if (stripped !== v) this.updateDeviceForm.get('longitude')?.setValue(stripped, { emitEvent: false });
-        const latitude = this.updateDeviceForm.get('latitude')?.value;
-        this.updateMapMarkers(latitude, stripped);
-      });
+    this.updateDeviceForm.get('latitude')?.valueChanges.subscribe((v) => {
+      const stripped = typeof v === 'string' ? v.replace(/\s/g, '') : v;
+      if (stripped !== v)
+        this.updateDeviceForm
+          .get('latitude')
+          ?.setValue(stripped, { emitEvent: false });
+      const longitude = this.updateDeviceForm.get('longitude')?.value;
+      this.updateMapMarkers(stripped, longitude);
+    });
+    this.updateDeviceForm.get('longitude')?.valueChanges.subscribe((v) => {
+      const stripped = typeof v === 'string' ? v.replace(/\s/g, '') : v;
+      if (stripped !== v)
+        this.updateDeviceForm
+          .get('longitude')
+          ?.setValue(stripped, { emitEvent: false });
+      const latitude = this.updateDeviceForm.get('latitude')?.value;
+      this.updateMapMarkers(latitude, stripped);
+    });
     forkJoin({
       countrylist: this.authService.GetMethod('countrycode/list'),
       sdgblist: this.authService.GetMethod('sdgbenefit/code'),
@@ -520,7 +555,9 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
         this.gridInterconnection = data.gridInterconnection;
         this.operatingConfiguration = data.operatingConfiguration || null;
         this.sourceAccessMode = data.sourceAccessMode || null;
-        this.evidenceReqs = getEvidenceRequirements(this.operatingConfiguration);
+        this.evidenceReqs = getEvidenceRequirements(
+          this.operatingConfiguration,
+        );
         this.deviceDescription = data.deviceDescription;
         this.stateProvince = data.stateProvince;
         this.organizationId = data.organizationId;
@@ -549,10 +586,17 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
             let prev = '';
             while (name !== prev) {
               prev = name;
-              try { name = decodeURIComponent(name); } catch { break; }
+              try {
+                name = decodeURIComponent(name);
+              } catch {
+                break;
+              }
             }
             // Strip embedded UUIDs
-            name = name.replace(/-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '');
+            name = name.replace(
+              /-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+              '',
+            );
             // Strip upload timestamp+index suffix (e.g. _1752226304295_1.pdf → .pdf)
             name = name.replace(/_\d{10,}_\d+\./, '.');
             this.existingDocs[doc.type].push({
@@ -566,23 +610,48 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
           this.brokenDocs = {};
           for (const type of Object.keys(this.existingDocs)) {
             for (const doc of this.existingDocs[type]) {
-              if (!doc.url) { this.brokenDocs[type] = true; continue; }
+              if (!doc.url) {
+                this.brokenDocs[type] = true;
+                continue;
+              }
               const ctrl = new AbortController();
-              fetch(doc.url, { method: 'GET', mode: 'cors', signal: ctrl.signal }).then(
-                (res) => { ctrl.abort(); if (!res.ok) this.brokenDocs[type] = true; },
-                (err) => { if (err?.name !== 'AbortError') this.brokenDocs[type] = true; },
+              fetch(doc.url, {
+                method: 'GET',
+                mode: 'cors',
+                signal: ctrl.signal,
+              }).then(
+                (res) => {
+                  ctrl.abort();
+                  if (!res.ok) this.brokenDocs[type] = true;
+                },
+                (err) => {
+                  if (err?.name !== 'AbortError') this.brokenDocs[type] = true;
+                },
               );
             }
             // Pre-populate filePreviews for existing docs so View button shows
             if (!this.filePreviews[type] && this.existingDocs[type]?.length) {
               const doc = this.existingDocs[type][0];
               const ext = doc.name.split('.').pop()?.toLowerCase() || '';
-              const isImage = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext);
+              const isImage = [
+                'jpg',
+                'jpeg',
+                'png',
+                'gif',
+                'webp',
+                'bmp',
+              ].includes(ext);
               const isPdf = ext === 'pdf';
               const isExcel = ext === 'xlsx' || ext === 'xls';
               this.filePreviews[type] = {
                 url: this.sanitizer.bypassSecurityTrustResourceUrl(doc.url),
-                type: isImage ? 'image' : isPdf ? 'pdf' : isExcel ? 'excel' : 'other',
+                type: isImage
+                  ? 'image'
+                  : isPdf
+                    ? 'pdf'
+                    : isExcel
+                      ? 'excel'
+                      : 'other',
                 name: doc.name,
               };
             }
@@ -669,10 +738,11 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
       return;
     }
     const ext = (d.name.split('.').pop() || '').toLowerCase();
-    const type: 'image' | 'pdf' | 'excel' | 'other' =
-      this.isPdfFile(d.name) ? 'pdf'
-      : ext === 'xlsx' || ext === 'xls' ? 'excel'
-      : 'other';
+    const type: 'image' | 'pdf' | 'excel' | 'other' = this.isPdfFile(d.name)
+      ? 'pdf'
+      : ext === 'xlsx' || ext === 'xls'
+        ? 'excel'
+        : 'other';
     this.previewData = {
       url: this.sanitizer.bypassSecurityTrustResourceUrl(d.url),
       type,
@@ -699,9 +769,13 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
       this.organizationId ?? this.loginuser?.organizationId,
     );
     if (this.updateDeviceForm.controls['serialNumber'].value == null) {
-      this.updateDeviceForm.controls['serialNumber'].setValue(this.serialNumber);
+      this.updateDeviceForm.controls['serialNumber'].setValue(
+        this.serialNumber,
+      );
     }
-    this.updateDeviceForm.controls['countryCode'].setValue(selectedCountry?.alpha3);
+    this.updateDeviceForm.controls['countryCode'].setValue(
+      selectedCountry?.alpha3,
+    );
 
     // Capture the form value once — .value returns a new snapshot each call
     const formValue = this.updateDeviceForm.value;
@@ -713,7 +787,9 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
     }
     if (formValue.longitude) {
       const [intLng, decLng] = String(formValue.longitude).split('.');
-      formValue.longitude = decLng ? `${intLng}.${decLng.slice(0, 20)}` : intLng;
+      formValue.longitude = decLng
+        ? `${intLng}.${decLng.slice(0, 20)}`
+        : intLng;
     }
 
     // OC#37 is a multi-select in the UI but stored as a '; '-joined string
@@ -727,15 +803,18 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
     // covers null/undefined — a null → Transform → NaN still fails IsNumber).
     for (const k of Object.keys(formValue)) {
       const v = (formValue as any)[k];
-      if (v === null || v === undefined || v === '' || (typeof v === 'number' && isNaN(v))) {
+      if (
+        v === null ||
+        v === undefined ||
+        v === '' ||
+        (typeof v === 'number' && isNaN(v))
+      ) {
         delete (formValue as any)[k];
       }
     }
 
     // Check if any files were selected
-    const hasFiles = this.fileTypes.some(
-      (ft) => this.files[ft]?.length > 0,
-    );
+    const hasFiles = this.fileTypes.some((ft) => this.files[ft]?.length > 0);
 
     let payload: FormData | Record<string, any>;
 
@@ -779,7 +858,8 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
       .update(
         this.externalid,
         payload,
-        this.updateDeviceForm.controls['serialNumber'].value !== this.initSerialNumber,
+        this.updateDeviceForm.controls['serialNumber'].value !==
+          this.initSerialNumber,
       )
       .subscribe({
         next: (data: any) => {
@@ -833,8 +913,12 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
         lng: this.longitude,
       };
     }
-    this.updateDeviceForm.get('latitude')?.setValue(center.lat, { emitEvent: false });
-    this.updateDeviceForm.get('longitude')?.setValue(center.lng, { emitEvent: false });
+    this.updateDeviceForm
+      .get('latitude')
+      ?.setValue(center.lat, { emitEvent: false });
+    this.updateDeviceForm
+      .get('longitude')
+      ?.setValue(center.lng, { emitEvent: false });
     this.latitude = String(center.lat);
     this.longitude = String(center.lng);
     // Only mark dirty if coords actually changed from the original
@@ -848,8 +932,12 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
     if (!this.savedCoords) return;
     this.latitude = this.savedCoords.lat;
     this.longitude = this.savedCoords.lng;
-    this.updateDeviceForm.get('latitude')?.setValue(this.savedCoords.lat, { emitEvent: false });
-    this.updateDeviceForm.get('longitude')?.setValue(this.savedCoords.lng, { emitEvent: false });
+    this.updateDeviceForm
+      .get('latitude')
+      ?.setValue(this.savedCoords.lat, { emitEvent: false });
+    this.updateDeviceForm
+      .get('longitude')
+      ?.setValue(this.savedCoords.lng, { emitEvent: false });
     const lat = parseFloat(this.savedCoords.lat);
     const lng = parseFloat(this.savedCoords.lng);
     if (!isNaN(lat) && !isNaN(lng)) {
@@ -869,9 +957,13 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
       this.organizationId ?? this.loginuser?.organizationId,
     );
     if (this.updateDeviceForm.controls['serialNumber'].value == null) {
-      this.updateDeviceForm.controls['serialNumber'].setValue(this.serialNumber);
+      this.updateDeviceForm.controls['serialNumber'].setValue(
+        this.serialNumber,
+      );
     }
-    this.updateDeviceForm.controls['countryCode'].setValue(selectedCountry?.alpha3);
+    this.updateDeviceForm.controls['countryCode'].setValue(
+      selectedCountry?.alpha3,
+    );
 
     const formValue = { ...this.updateDeviceForm.value };
     if (formValue.latitude) {
@@ -880,29 +972,35 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
     }
     if (formValue.longitude) {
       const [intLng, decLng] = String(formValue.longitude).split('.');
-      formValue.longitude = decLng ? `${intLng}.${decLng.slice(0, 20)}` : intLng;
+      formValue.longitude = decLng
+        ? `${intLng}.${decLng.slice(0, 20)}`
+        : intLng;
     }
 
-    this.deviceService
-      .update(this.externalid, formValue, false)
-      .subscribe({
-        next: () => {
-          this.toastrService.success('Coordinates saved');
-          this.savedCoords = null;
-          this.coordsDirty = false;
-          // Restore country display name so form still shows it correctly
-          if (selectedCountry) {
-            this.updateDeviceForm.controls['countryCode'].setValue(selectedCountry.country);
-          }
-        },
-        error: (err: any) => {
-          this.toastrService.error(err.error?.message || 'Failed to save coordinates');
-          // Restore country display name on error too
-          if (selectedCountry) {
-            this.updateDeviceForm.controls['countryCode'].setValue(selectedCountry.country);
-          }
-        },
-      });
+    this.deviceService.update(this.externalid, formValue, false).subscribe({
+      next: () => {
+        this.toastrService.success('Coordinates saved');
+        this.savedCoords = null;
+        this.coordsDirty = false;
+        // Restore country display name so form still shows it correctly
+        if (selectedCountry) {
+          this.updateDeviceForm.controls['countryCode'].setValue(
+            selectedCountry.country,
+          );
+        }
+      },
+      error: (err: any) => {
+        this.toastrService.error(
+          err.error?.message || 'Failed to save coordinates',
+        );
+        // Restore country display name on error too
+        if (selectedCountry) {
+          this.updateDeviceForm.controls['countryCode'].setValue(
+            selectedCountry.country,
+          );
+        }
+      },
+    });
   }
 
   onScreenshotFromMap(file: File): void {
@@ -920,7 +1018,10 @@ export class EditDeviceComponent implements OnInit, OnDestroy {
       name: file.name,
     };
 
-    this.toastrService.success(`Map capture "${file.name}" added as metering evidence`, 'Captured');
+    this.toastrService.success(
+      `Map capture "${file.name}" added as metering evidence`,
+      'Captured',
+    );
   }
 
   updateMapMarkers(latitude: any, longitude: any) {

--- a/src/app/view/documents-upload/documents-upload.component.ts
+++ b/src/app/view/documents-upload/documents-upload.component.ts
@@ -187,7 +187,10 @@ export class DocumentsUploadComponent {
           const user = JSON.parse(sessionStorage.getItem('loginuser') || '{}');
           if (user.role === OrganizationType.Registrant) {
             this.authService
-              .RegistrantExportAccesskey('user/export-accesskey/', this.userApiId)
+              .RegistrantExportAccesskey(
+                'user/export-accesskey/',
+                this.userApiId,
+              )
               .subscribe({
                 next: (keydata: any) => {
                   this.downloadAccessKey(keydata);

--- a/src/app/view/map/map.component.ts
+++ b/src/app/view/map/map.component.ts
@@ -1,4 +1,16 @@
-import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild, NgZone } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
+  NgZone,
+} from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import * as L from 'leaflet';
 import { environment } from '../../../environments/environment';
@@ -12,11 +24,17 @@ export interface MapMarker {
   siteName?: string;
 }
 
-export function satelliteTileUrl(lat: number, lng: number, zoom: number = 18): string {
+export function satelliteTileUrl(
+  lat: number,
+  lng: number,
+  zoom: number = 18,
+): string {
   const n = Math.pow(2, zoom);
-  const x = Math.floor((lng + 180) / 360 * n);
-  const latRad = lat * Math.PI / 180;
-  const y = Math.floor((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2 * n);
+  const x = Math.floor(((lng + 180) / 360) * n);
+  const latRad = (lat * Math.PI) / 180;
+  const y = Math.floor(
+    ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n,
+  );
   return `https://mt1.google.com/vt/lyrs=s&x=${x}&y=${y}&z=${zoom}`;
 }
 
@@ -27,11 +45,16 @@ export interface SatellitePreview {
 }
 
 /** Returns a 2x2 tile grid + offsets to render a 256px view centered on the coordinate. */
-export function satellitePreview(lat: number, lng: number, zoom: number = 19): SatellitePreview {
+export function satellitePreview(
+  lat: number,
+  lng: number,
+  zoom: number = 19,
+): SatellitePreview {
   const n = Math.pow(2, zoom);
-  const xFrac = (lng + 180) / 360 * n;
-  const latRad = lat * Math.PI / 180;
-  const yFrac = (1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2 * n;
+  const xFrac = ((lng + 180) / 360) * n;
+  const latRad = (lat * Math.PI) / 180;
+  const yFrac =
+    ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n;
 
   const tileX = Math.floor(xFrac);
   const tileY = Math.floor(yFrac);
@@ -118,10 +141,15 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
   // Screenshot capture
   @Output() screenshotTaken = new EventEmitter<File>();
 
-  constructor(private http: HttpClient, private zone: NgZone) {}
+  constructor(
+    private http: HttpClient,
+    private zone: NgZone,
+  ) {}
 
   ngOnInit(): void {
-    this.options.layers = [this.satellite ? this.createSatelliteLayer() : this.createTileLayer()];
+    this.options.layers = [
+      this.satellite ? this.createSatelliteLayer() : this.createTileLayer(),
+    ];
     this.options.scrollWheelZoom = this.scrollWheelZoom;
     if (this.centerPin) {
       this.options.zoomAnimation = false;
@@ -157,7 +185,10 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
         const c = this.map.getCenter();
         this.centerPinMarker?.setLatLng(c);
         if (dragging) {
-          this.centerChanged.emit({ lat: +c.lat.toFixed(6), lng: +c.lng.toFixed(6) });
+          this.centerChanged.emit({
+            lat: +c.lat.toFixed(6),
+            lng: +c.lng.toFixed(6),
+          });
         }
       });
       this.map.on('moveend', () => {
@@ -184,7 +215,9 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     // Fix existing tiles
-    tilePane.querySelectorAll('img').forEach((img) => fix(img as HTMLImageElement));
+    tilePane
+      .querySelectorAll('img')
+      .forEach((img) => fix(img as HTMLImageElement));
 
     // Watch for new tiles
     this.tileObserver = new MutationObserver((mutations) => {
@@ -193,7 +226,9 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
           if (node instanceof HTMLImageElement) {
             fix(node);
           } else if (node instanceof HTMLElement) {
-            node.querySelectorAll('img').forEach((img) => fix(img as HTMLImageElement));
+            node
+              .querySelectorAll('img')
+              .forEach((img) => fix(img as HTMLImageElement));
           }
         }
       }
@@ -257,7 +292,9 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
       if (!this.centerPinInitialized && this.markers?.length) {
         const m = this.markers[0];
         if (!isNaN(m.latitude) && !isNaN(m.longitude)) {
-          this.map.setView([m.latitude, m.longitude], this.zoom, { animate: false });
+          this.map.setView([m.latitude, m.longitude], this.zoom, {
+            animate: false,
+          });
           this.ensureCenterPin([m.latitude, m.longitude]);
           this.centerPinMarker?.setLatLng([m.latitude, m.longitude]);
           this.centerPinInitialized = true;
@@ -392,9 +429,17 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
 
     // Verify canvas isn't blank
     const sample = srcCtx.getImageData(
-      Math.floor(w / 2), Math.floor(h / 2), 1, 1,
+      Math.floor(w / 2),
+      Math.floor(h / 2),
+      1,
+      1,
     ).data;
-    if (sample[0] === 0 && sample[1] === 0 && sample[2] === 0 && sample[3] === 0) {
+    if (
+      sample[0] === 0 &&
+      sample[1] === 0 &&
+      sample[2] === 0 &&
+      sample[3] === 0
+    ) {
       this.detecting = false;
       this.detectError = 'Could not capture map tiles (CORS)';
       return;
@@ -413,27 +458,43 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
     cropCanvas.width = Math.round(cropW * scale);
     cropCanvas.height = Math.round(cropH * scale);
     const cropCtx = cropCanvas.getContext('2d')!;
-    cropCtx.drawImage(srcCanvas, cropX, cropY, cropW, cropH,
-      0, 0, cropCanvas.width, cropCanvas.height);
+    cropCtx.drawImage(
+      srcCanvas,
+      cropX,
+      cropY,
+      cropW,
+      cropH,
+      0,
+      0,
+      cropCanvas.width,
+      cropCanvas.height,
+    );
 
     const base64 = cropCanvas.toDataURL('image/jpeg', 0.85).split(',')[1];
 
-    this.http.post<any>(
-      `${environment.API_URL}device-reviews/detect-panels`,
-      { image: base64 },
-    ).subscribe({
-      next: (data) => this.drawDetections(data, w, h, cropX, cropY, cropW, cropH),
-      error: (err) => {
-        this.detectError =
-          'Detection failed: ' + (err?.error?.message || err?.message || err);
-        this.detecting = false;
-      },
-    });
+    this.http
+      .post<any>(`${environment.API_URL}device-reviews/detect-panels`, {
+        image: base64,
+      })
+      .subscribe({
+        next: (data) =>
+          this.drawDetections(data, w, h, cropX, cropY, cropW, cropH),
+        error: (err) => {
+          this.detectError =
+            'Detection failed: ' + (err?.error?.message || err?.message || err);
+          this.detecting = false;
+        },
+      });
   }
 
   private drawDetections(
-    data: any, w: number, h: number,
-    cropX: number, cropY: number, cropW: number, cropH: number,
+    data: any,
+    w: number,
+    h: number,
+    cropX: number,
+    cropY: number,
+    cropW: number,
+    cropH: number,
   ): void {
     const canvas = this.overlayCanvas.nativeElement;
     canvas.width = w;
@@ -478,7 +539,9 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
       const dx = x - this.deleteBtn.x;
       const dy = y - this.deleteBtn.y;
       if (dx * dx + dy * dy <= this.deleteBtn.r * this.deleteBtn.r) {
-        this.predictions = this.predictions.filter((_: any, i: number) => i !== this.selectedRegion);
+        this.predictions = this.predictions.filter(
+          (_: any, i: number) => i !== this.selectedRegion,
+        );
         this.selectedRegion = -1;
         this.deleteBtn = null;
         this.panelCount = this.predictions.length;
@@ -526,12 +589,22 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
       }
     }
 
-    canvas.style.cursor = this.predictions.some((p: any) => this.regionHitTest(p, x, y)) ? 'default' : 'grab';
+    canvas.style.cursor = this.predictions.some((p: any) =>
+      this.regionHitTest(p, x, y),
+    )
+      ? 'default'
+      : 'grab';
   }
 
   deleteSelectedRegion(): void {
-    if (this.selectedRegion < 0 || this.selectedRegion >= this.predictions.length) return;
-    this.predictions = this.predictions.filter((_: any, i: number) => i !== this.selectedRegion);
+    if (
+      this.selectedRegion < 0 ||
+      this.selectedRegion >= this.predictions.length
+    )
+      return;
+    this.predictions = this.predictions.filter(
+      (_: any, i: number) => i !== this.selectedRegion,
+    );
     this.selectedRegion = -1;
     this.panelCount = this.predictions.length;
     const canvas = this.overlayCanvas.nativeElement;
@@ -553,9 +626,14 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
       }));
       let inside = false;
       for (let i = 0, j = scaled.length - 1; i < scaled.length; j = i++) {
-        const xi = scaled[i].x, yi = scaled[i].y;
-        const xj = scaled[j].x, yj = scaled[j].y;
-        if (((yi > my) !== (yj > my)) && (mx < (xj - xi) * (my - yi) / (yj - yi) + xi)) {
+        const xi = scaled[i].x,
+          yi = scaled[i].y;
+        const xj = scaled[j].x,
+          yj = scaled[j].y;
+        if (
+          yi > my !== yj > my &&
+          mx < ((xj - xi) * (my - yi)) / (yj - yi) + xi
+        ) {
           inside = !inside;
         }
       }
@@ -576,24 +654,42 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
     // Re-draw any committed drawn rectangle
     if (this.drawnRect) {
       ctx.fillStyle = 'rgba(0, 255, 180, 0.3)';
-      ctx.fillRect(this.drawnRect.x, this.drawnRect.y, this.drawnRect.w, this.drawnRect.h);
+      ctx.fillRect(
+        this.drawnRect.x,
+        this.drawnRect.y,
+        this.drawnRect.w,
+        this.drawnRect.h,
+      );
       ctx.strokeStyle = '#00ffb4';
       ctx.lineWidth = 2;
-      ctx.strokeRect(this.drawnRect.x, this.drawnRect.y, this.drawnRect.w, this.drawnRect.h);
+      ctx.strokeRect(
+        this.drawnRect.x,
+        this.drawnRect.y,
+        this.drawnRect.w,
+        this.drawnRect.h,
+      );
     }
 
     for (let i = 0; i < this.predictions.length; i++) {
       const pred = this.predictions[i];
       const selected = i === this.selectedRegion;
-      const fill = selected ? 'rgba(239, 68, 68, 0.4)' : 'rgba(0, 255, 180, 0.3)';
+      const fill = selected
+        ? 'rgba(239, 68, 68, 0.4)'
+        : 'rgba(0, 255, 180, 0.3)';
       const stroke = selected ? '#ef4444' : '#00ffb4';
       const points: { x: number; y: number }[] = pred.points ?? [];
 
       if (points.length > 2) {
         ctx.beginPath();
-        ctx.moveTo(points[0].x * this.detScaleX + this.detCropX, points[0].y * this.detScaleY + this.detCropY);
+        ctx.moveTo(
+          points[0].x * this.detScaleX + this.detCropX,
+          points[0].y * this.detScaleY + this.detCropY,
+        );
         for (let j = 1; j < points.length; j++) {
-          ctx.lineTo(points[j].x * this.detScaleX + this.detCropX, points[j].y * this.detScaleY + this.detCropY);
+          ctx.lineTo(
+            points[j].x * this.detScaleX + this.detCropX,
+            points[j].y * this.detScaleY + this.detCropY,
+          );
         }
         ctx.closePath();
         ctx.fillStyle = fill;
@@ -617,8 +713,12 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
       if (selected) {
         let dotX: number, dotY: number;
         if (points.length > 2) {
-          const xs = points.map((p: any) => p.x * this.detScaleX + this.detCropX);
-          const ys = points.map((p: any) => p.y * this.detScaleY + this.detCropY);
+          const xs = points.map(
+            (p: any) => p.x * this.detScaleX + this.detCropX,
+          );
+          const ys = points.map(
+            (p: any) => p.y * this.detScaleY + this.detCropY,
+          );
           dotX = Math.max(...xs);
           dotY = Math.min(...ys);
         } else {
@@ -662,7 +762,10 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
     if (!this.drawMode) return;
     const canvas = this.overlayCanvas.nativeElement;
     const rect = canvas.getBoundingClientRect();
-    this.rectStart = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+    this.rectStart = {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
     this.rectDragging = true;
   }
 
@@ -699,7 +802,12 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
     this.redrawOverlay(this.drawnRect);
   }
 
-  private redrawOverlay(tempRect?: { x: number; y: number; w: number; h: number }): void {
+  private redrawOverlay(tempRect?: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  }): void {
     const canvas = this.overlayCanvas.nativeElement;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
@@ -747,7 +855,13 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
       for (const img of imgs) {
         const r = img.getBoundingClientRect();
         try {
-          outCtx.drawImage(img, r.left - mapRect.left, r.top - mapRect.top, r.width, r.height);
+          outCtx.drawImage(
+            img,
+            r.left - mapRect.left,
+            r.top - mapRect.top,
+            r.width,
+            r.height,
+          );
         } catch {
           // CORS fallback: re-fetch as blob
           const src = img.getAttribute('src');
@@ -756,9 +870,17 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
             const resp = await fetch(src);
             const blob = await resp.blob();
             const bmp = await createImageBitmap(blob);
-            outCtx.drawImage(bmp, r.left - mapRect.left, r.top - mapRect.top, r.width, r.height);
+            outCtx.drawImage(
+              bmp,
+              r.left - mapRect.left,
+              r.top - mapRect.top,
+              r.width,
+              r.height,
+            );
             bmp.close();
-          } catch { /* skip */ }
+          } catch {
+            /* skip */
+          }
         }
       }
     }
@@ -769,7 +891,9 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     // Draw marker pane (pins — DivIcon SVGs) on top of overlay
-    const markerPane = mapEl.querySelector('.leaflet-marker-pane') as HTMLElement;
+    const markerPane = mapEl.querySelector(
+      '.leaflet-marker-pane',
+    ) as HTMLElement;
     if (markerPane) {
       const svgs = Array.from(markerPane.querySelectorAll('svg'));
       for (const svg of svgs) {
@@ -777,7 +901,9 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
         if (!parent) continue;
         const r = parent.getBoundingClientRect();
         const svgData = new XMLSerializer().serializeToString(svg);
-        const svgBlob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+        const svgBlob = new Blob([svgData], {
+          type: 'image/svg+xml;charset=utf-8',
+        });
         const url = URL.createObjectURL(svgBlob);
         try {
           const img = new Image();
@@ -788,18 +914,30 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
             img.onerror = reject;
             img.src = url;
           });
-          outCtx.drawImage(img, r.left - mapRect.left, r.top - mapRect.top, r.width, r.height);
-        } catch { /* skip */ }
+          outCtx.drawImage(
+            img,
+            r.left - mapRect.left,
+            r.top - mapRect.top,
+            r.width,
+            r.height,
+          );
+        } catch {
+          /* skip */
+        }
         URL.revokeObjectURL(url);
       }
     }
 
-    outCanvas.toBlob((blob) => {
-      if (!blob) return;
-      const filename = name.replace(/[^a-zA-Z0-9_\- ]/g, '') + '.jpg';
-      const file = new File([blob], filename, { type: 'image/jpeg' });
-      this.zone.run(() => this.screenshotTaken.emit(file));
-    }, 'image/jpeg', 0.85);
+    outCanvas.toBlob(
+      (blob) => {
+        if (!blob) return;
+        const filename = name.replace(/[^a-zA-Z0-9_\- ]/g, '') + '.jpg';
+        const file = new File([blob], filename, { type: 'image/jpeg' });
+        this.zone.run(() => this.screenshotTaken.emit(file));
+      },
+      'image/jpeg',
+      0.85,
+    );
   }
 
   private pinOverlay: HTMLElement | null = null;
@@ -832,16 +970,13 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private createSatelliteLayer(): L.TileLayer {
-    return L.tileLayer(
-      'https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}',
-      {
-        minZoom: 3,
-        maxZoom: 21,
-        noWrap: true,
-        attribution: '&copy; Google',
-        crossOrigin: true,
-      } as any,
-    );
+    return L.tileLayer('https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
+      minZoom: 3,
+      maxZoom: 21,
+      noWrap: true,
+      attribution: '&copy; Google',
+      crossOrigin: true,
+    } as any);
   }
 
   // --- Markers ---
@@ -878,10 +1013,16 @@ export class MapComponent implements OnInit, OnChanges, OnDestroy {
         if (!this.satPreviewEnabled) return;
         this.removePinOverlay();
         this.pinOverlay = SatellitePreviewComponent.createOverlay(
-          label, latitude, longitude, this.http,
+          label,
+          latitude,
+          longitude,
+          this.http,
         );
         SatellitePreviewComponent.positionOverlay(
-          this.pinOverlay, this.map!, latitude, longitude,
+          this.pinOverlay,
+          this.map!,
+          latitude,
+          longitude,
         );
       });
 

--- a/src/app/view/meter-read-reviews/meter-read-review.service.ts
+++ b/src/app/view/meter-read-reviews/meter-read-review.service.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subject, map } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { MeterReadReviewDevice, MeterReadEntry } from './meter-read-review.model';
+import {
+  MeterReadReviewDevice,
+  MeterReadEntry,
+} from './meter-read-review.model';
 
 @Injectable()
 export class MeterReadReviewService {
@@ -28,9 +31,9 @@ export class MeterReadReviewService {
     this.loading$.next(true);
     this.error$.next(null);
     this.http
-      .get<MeterReadReviewDevice[]>(
-        environment.API_URL + 'device-reviews/meter-reads',
-      )
+      .get<
+        MeterReadReviewDevice[]
+      >(environment.API_URL + 'device-reviews/meter-reads')
       .subscribe({
         next: (devices) => {
           const mapped = devices.map((d) => ({ ...d, reads: [] }));
@@ -62,7 +65,9 @@ export class MeterReadReviewService {
 
   loadReads(deviceId: number): Observable<MeterReadEntry[]> {
     return this.http
-      .get<any>(environment.API_URL + `device-reviews/meter-reads/${deviceId}/reads`)
+      .get<any>(
+        environment.API_URL + `device-reviews/meter-reads/${deviceId}/reads`,
+      )
       .pipe(
         map((data: any[]) =>
           data.map((r) => ({
@@ -95,17 +100,19 @@ export class MeterReadReviewService {
     status: string,
     reviewer?: string,
   ): Observable<Array<{ deviceId: number; status: string; error?: string }>> {
-    return this.http.patch<Array<{ deviceId: number; status: string; error?: string }>>(
-      environment.API_URL + 'device-reviews/meter-reads/bulk/status',
-      { deviceIds, status, reviewer },
-    );
+    return this.http.patch<
+      Array<{ deviceId: number; status: string; error?: string }>
+    >(environment.API_URL + 'device-reviews/meter-reads/bulk/status', {
+      deviceIds,
+      status,
+      reviewer,
+    });
   }
 
   // Reuse existing device-reviews verification endpoints
   reviewHistoricalConsistency(deviceId: number): Observable<any> {
     return this.http.get(
-      environment.API_URL +
-        `device-reviews/${deviceId}/historical-consistency`,
+      environment.API_URL + `device-reviews/${deviceId}/historical-consistency`,
     );
   }
 
@@ -121,7 +128,12 @@ export class MeterReadReviewService {
     );
   }
 
-  flagMeterRead(deviceId: number, readId: number, reason: string, reviewer?: string): Observable<{ logged: boolean }> {
+  flagMeterRead(
+    deviceId: number,
+    readId: number,
+    reason: string,
+    reviewer?: string,
+  ): Observable<{ logged: boolean }> {
     return this.http.post<{ logged: boolean }>(
       environment.API_URL + `device-reviews/meter-reads/${deviceId}/flag-read`,
       { readId, reason, reviewer },
@@ -130,7 +142,8 @@ export class MeterReadReviewService {
 
   gapAnalysis(deviceId: number): Observable<any> {
     return this.http.post(
-      environment.API_URL + `device-reviews/meter-reads/${deviceId}/gap-analysis`,
+      environment.API_URL +
+        `device-reviews/meter-reads/${deviceId}/gap-analysis`,
       {},
     );
   }

--- a/src/app/view/meter-read-reviews/meter-read-reviews-page.component.ts
+++ b/src/app/view/meter-read-reviews/meter-read-reviews-page.component.ts
@@ -8,16 +8,36 @@ import { MeterReadReviewService } from './meter-read-review.service';
     <div class="mrr-page">
       <ng-container *ngIf="canReview; else chatListView">
         <div class="ds-tabs">
-          <button class="ds-tab" [class.ds-tab--active]="activeTab === 'reviews'" (click)="activeTab = 'reviews'">Meter Read Reviews</button>
-          <button class="ds-tab" [class.ds-tab--active]="activeTab === 'map'" (click)="activeTab = 'map'">World Map</button>
+          <button
+            class="ds-tab"
+            [class.ds-tab--active]="activeTab === 'reviews'"
+            (click)="activeTab = 'reviews'"
+          >
+            Meter Read Reviews
+          </button>
+          <button
+            class="ds-tab"
+            [class.ds-tab--active]="activeTab === 'map'"
+            (click)="activeTab = 'map'"
+          >
+            World Map
+          </button>
         </div>
         <div class="mrr-content">
-          <app-mrr-reads-list *ngIf="activeTab === 'reviews'"></app-mrr-reads-list>
-          <app-mrr-map-window *ngIf="activeTab === 'map'" (onPinClick)="onMapPinClick($event)"></app-mrr-map-window>
+          <app-mrr-reads-list
+            *ngIf="activeTab === 'reviews'"
+          ></app-mrr-reads-list>
+          <app-mrr-map-window
+            *ngIf="activeTab === 'map'"
+            (onPinClick)="onMapPinClick($event)"
+          ></app-mrr-map-window>
         </div>
       </ng-container>
       <ng-template #chatListView>
-        <div class="mrr-content" style="display:flex;align-items:center;justify-content:center;color:#64748b;">
+        <div
+          class="mrr-content"
+          style="display:flex;align-items:center;justify-content:center;color:#64748b;"
+        >
           Meter read reviews are available to reviewers and admins only.
         </div>
       </ng-template>

--- a/src/app/view/meter-read-reviews/reads-list-window/reads-list-window.component.ts
+++ b/src/app/view/meter-read-reviews/reads-list-window/reads-list-window.component.ts
@@ -51,7 +51,12 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
     rejected: false,
   };
 
-  sortField: 'siteName' | 'readCount' | 'latestReadDate' | 'totalKwh' | 'reviewStatus' = 'latestReadDate';
+  sortField:
+    | 'siteName'
+    | 'readCount'
+    | 'latestReadDate'
+    | 'totalKwh'
+    | 'reviewStatus' = 'latestReadDate';
   sortDir: 'asc' | 'desc' = 'desc';
 
   filteredDevices: FilteredRow[] = [];
@@ -63,7 +68,9 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
 
   get editingDevice(): MeterReadReviewDevice | null {
     if (this.editingId === null) return null;
-    return this.svc.devices$.value.find((d) => d.deviceId === this.editingId) ?? null;
+    return (
+      this.svc.devices$.value.find((d) => d.deviceId === this.editingId) ?? null
+    );
   }
 
   // Verification state
@@ -176,9 +183,15 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
     }
     if (e.key === 'Escape') {
       if (this.closeTopModal()) return;
-      if (this.editingId !== null) { this.closeDetail(); return; }
+      if (this.editingId !== null) {
+        this.closeDetail();
+        return;
+      }
     }
-    if ((e.key === 'ArrowUp' || e.key === 'ArrowDown') && !this.hasOpenModal()) {
+    if (
+      (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
+      !this.hasOpenModal()
+    ) {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
       e.preventDefault();
@@ -187,14 +200,22 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
   }
 
   private hasOpenModal(): boolean {
-    return this.showConsistencyModal || this.showCeilingModal
-      || this.showCrossSourceModal || this.showAuditModal || this.showGapModal;
+    return (
+      this.showConsistencyModal ||
+      this.showCeilingModal ||
+      this.showCrossSourceModal ||
+      this.showAuditModal ||
+      this.showGapModal
+    );
   }
 
   private closeTopModal(): boolean {
     const modals: (keyof this)[] = [
-      'showConsistencyModal', 'showCeilingModal',
-      'showCrossSourceModal', 'showAuditModal', 'showGapModal',
+      'showConsistencyModal',
+      'showCeilingModal',
+      'showCrossSourceModal',
+      'showAuditModal',
+      'showGapModal',
     ];
     for (const key of modals) {
       if (this[key]) {
@@ -207,8 +228,13 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
 
   private navigateList(dir: number): void {
     if (!this.filteredDevices.length) return;
-    const idx = this.filteredDevices.findIndex((r) => r.device.deviceId === this.editingId);
-    const next = Math.max(0, Math.min(this.filteredDevices.length - 1, idx + dir));
+    const idx = this.filteredDevices.findIndex(
+      (r) => r.device.deviceId === this.editingId,
+    );
+    const next = Math.max(
+      0,
+      Math.min(this.filteredDevices.length - 1, idx + dir),
+    );
     if (!this.confirmDiscard()) return;
     this.openDetail(this.filteredDevices[next].device.deviceId);
   }
@@ -255,11 +281,14 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
   }
 
   openDetail(deviceId: number): void {
-    if (this.editingId !== null && this.editingId !== deviceId && !this.confirmDiscard()) return;
+    if (
+      this.editingId !== null &&
+      this.editingId !== deviceId &&
+      !this.confirmDiscard()
+    )
+      return;
     this.editingId = deviceId;
-    const device = this.svc.devices$.value.find(
-      (d) => d.deviceId === deviceId,
-    );
+    const device = this.svc.devices$.value.find((d) => d.deviceId === deviceId);
     if (device) {
       this.detailForm.patchValue({
         reviewStatus: device.reviewStatus,
@@ -353,9 +382,7 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
     const email = loginUser.email;
     if (!email) return;
 
-    const device = this.svc.devices$.value.find(
-      (d) => d.siteName === siteName,
-    );
+    const device = this.svc.devices$.value.find((d) => d.siteName === siteName);
     const submitter = device?.submitterEmail;
     if (!submitter) return;
 
@@ -439,16 +466,18 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
     const reviewer = loginUser.firstName
       ? `${loginUser.firstName} ${loginUser.lastName || ''}`.trim()
       : loginUser.email || 'reviewer';
-    this.svc.flagMeterRead(device.deviceId, read.id, reason, reviewer).subscribe({
-      next: () => {
-        this.flaggedReads[read.id] = true;
-        this.toast(`Read #${read.id} flagged`);
-        this.cdr.markForCheck();
-      },
-      error: (err) => {
-        this.toast(err?.error?.message || 'Flag failed', 5000);
-      },
-    });
+    this.svc
+      .flagMeterRead(device.deviceId, read.id, reason, reviewer)
+      .subscribe({
+        next: () => {
+          this.flaggedReads[read.id] = true;
+          this.toast(`Read #${read.id} flagged`);
+          this.cdr.markForCheck();
+        },
+        error: (err) => {
+          this.toast(err?.error?.message || 'Flag failed', 5000);
+        },
+      });
   }
 
   checkGaps(): void {
@@ -520,8 +549,19 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
     const escape = (v: string) => `"${(v || '').replace(/"/g, '""')}"`;
     const header = 'Action,Performed By,Date,Detail';
     const rows = this.filteredAuditTrail.map((e: any) => {
-      const ts = new Date(e.createdAt).toLocaleString('en-GB', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
-      return [escape(e.actionType), escape(e.performedBy), escape(ts), escape(e.detail || '')].join(',');
+      const ts = new Date(e.createdAt).toLocaleString('en-GB', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      return [
+        escape(e.actionType),
+        escape(e.performedBy),
+        escape(ts),
+        escape(e.detail || ''),
+      ].join(',');
     });
     const csv = [header, ...rows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -558,7 +598,10 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
     if (!d) return '—';
     const dt = new Date(d);
     const date = dt.toLocaleDateString('en-GB');
-    const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+    const time = dt.toLocaleTimeString('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
     return `${date} ${time}`;
   }
 
@@ -570,10 +613,7 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
   hl(text: string, term: string): string {
     if (!term || !text) return text || '';
     const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return text.replace(
-      new RegExp(`(${escaped})`, 'gi'),
-      '<mark>$1</mark>',
-    );
+    return text.replace(new RegExp(`(${escaped})`, 'gi'), '<mark>$1</mark>');
   }
 
   // ── Bulk actions ──────────────────────────────────────────────────
@@ -582,7 +622,9 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
   bulkBusy = false;
 
   get checkedIds(): number[] {
-    return Object.keys(this.checked).filter((k) => this.checked[+k]).map(Number);
+    return Object.keys(this.checked)
+      .filter((k) => this.checked[+k])
+      .map(Number);
   }
 
   get checkedCount(): number {
@@ -596,14 +638,19 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
 
   toggleCheckAll(event: Event): void {
     event.stopPropagation();
-    const allChecked = this.filteredDevices.every((r) => this.checked[r.device.deviceId]);
+    const allChecked = this.filteredDevices.every(
+      (r) => this.checked[r.device.deviceId],
+    );
     for (const r of this.filteredDevices) {
       this.checked[r.device.deviceId] = !allChecked;
     }
   }
 
   isAllChecked(): boolean {
-    return this.filteredDevices.length > 0 && this.filteredDevices.every((r) => this.checked[r.device.deviceId]);
+    return (
+      this.filteredDevices.length > 0 &&
+      this.filteredDevices.every((r) => this.checked[r.device.deviceId])
+    );
   }
 
   bulkSetStatus(status: string): void {
@@ -618,7 +665,9 @@ export class ReadsListWindowComponent implements OnInit, OnDestroy {
     this.svc.bulkUpdateStatus(ids, status, reviewer).subscribe({
       next: () => {
         const devices = this.svc.devices$.value.map((d) =>
-          this.checked[d.deviceId] ? { ...d, reviewStatus: status as ReadReviewStatus, reviewer } : d,
+          this.checked[d.deviceId]
+            ? { ...d, reviewStatus: status as ReadReviewStatus, reviewer }
+            : d,
         );
         this.svc.devices$.next(devices);
         this.checked = {};

--- a/src/app/view/meter-read/addread/addread.component.ts
+++ b/src/app/view/meter-read/addread/addread.component.ts
@@ -74,7 +74,10 @@ export class AddreadComponent implements OnInit {
   ) {
     this.loginuser = JSON.parse(sessionStorage.getItem('loginuser')!);
 
-    if (this.loginuser.role === 'Admin' || this.loginuser.role === 'Registrant') {
+    if (
+      this.loginuser.role === 'Admin' ||
+      this.loginuser.role === 'Registrant'
+    ) {
       this.showmeter_readformadmin = true;
     } else {
       this.showmeter_readformadmin = false;

--- a/src/app/view/organization/admin-organization/admin-organization.component.ts
+++ b/src/app/view/organization/admin-organization/admin-organization.component.ts
@@ -14,7 +14,14 @@ import { getOrgTypeName } from '../../../utils/role-helper';
 })
 export class AdminOrganizationComponent {
   getOrgTypeName = getOrgTypeName;
-  displayedColumns = ['name', 'type', 'status', 'created', 'no of users', 'actions'];
+  displayedColumns = [
+    'name',
+    'type',
+    'status',
+    'created',
+    'no of users',
+    'actions',
+  ];
   @ViewChild(MatSort) sort: MatSort;
   dataSource: MatTableDataSource<any>;
   loginuser: any;
@@ -46,10 +53,11 @@ export class AdminOrganizationComponent {
       this.dataSource = new MatTableDataSource(this.allOrgs);
       return;
     }
-    const filtered = this.allOrgs.filter((org: any) =>
-      org.name?.toLowerCase().includes(term) ||
-      org.organizationType?.toLowerCase().includes(term) ||
-      org.status?.toLowerCase().includes(term),
+    const filtered = this.allOrgs.filter(
+      (org: any) =>
+        org.name?.toLowerCase().includes(term) ||
+        org.organizationType?.toLowerCase().includes(term) ||
+        org.status?.toLowerCase().includes(term),
     );
     this.dataSource = new MatTableDataSource(filtered);
   }
@@ -70,18 +78,16 @@ export class AdminOrganizationComponent {
       });
   }
   getRegistrantAllOrganization() {
-    this.orgService
-      .GetRegistrantAllOrganization(1, 10000)
-      .subscribe({
-        next: (data) => {
-          this.showlist = true;
-          this.allOrgs = data.organizations;
-          this.dataSource = new MatTableDataSource(this.allOrgs);
-          this.dataSource.sort = this.sort;
-        },
-        error: () => {
-          this.showlist = false;
-        },
-      });
+    this.orgService.GetRegistrantAllOrganization(1, 10000).subscribe({
+      next: (data) => {
+        this.showlist = true;
+        this.allOrgs = data.organizations;
+        this.dataSource = new MatTableDataSource(this.allOrgs);
+        this.dataSource.sort = this.sort;
+      },
+      error: () => {
+        this.showlist = false;
+      },
+    });
   }
 }

--- a/src/app/view/permission/permission-routing.module.ts
+++ b/src/app/view/permission/permission-routing.module.ts
@@ -9,7 +9,10 @@ const routes: Routes = [
   { path: 'acl_module', component: AclModulePermissionComponent },
   { path: 'user_role/list', component: UserpermissionComponent },
   { path: 'registrant_role/list', component: RegistrantPermissionComponent },
-  { path: 'registrant_role/list/:id', component: RegistrantPermissionComponent },
+  {
+    path: 'registrant_role/list/:id',
+    component: RegistrantPermissionComponent,
+  },
   { path: 'request/form', component: RegistrantPermissionFormComponent },
   { path: 'list', component: RegistrantPermissionComponent },
 ];

--- a/src/app/view/reset-password/reset-password.component.ts
+++ b/src/app/view/reset-password/reset-password.component.ts
@@ -122,10 +122,7 @@ export class ResetPasswordComponent {
       .subscribe({
         next: (data) => {
           this.submitting = false;
-          this.toastrService.success(
-            'Password set successfully!',
-            'Success',
-          );
+          this.toastrService.success('Password set successfully!', 'Success');
           this.router.navigate(['/login']);
         },
         error: (err) => {

--- a/src/app/view/user-profile/password-reset-dialog.component.ts
+++ b/src/app/view/user-profile/password-reset-dialog.component.ts
@@ -79,22 +79,20 @@ export class PasswordResetDialogComponent {
     if (this.resetpasswordform.invalid || this.submitting) return;
     this.submitting = true;
     const { oldPassword, newPassword } = this.resetpasswordform.value;
-    this.userService
-      .updateOwnPassword({ oldPassword, newPassword })
-      .subscribe({
-        next: () => {
-          this.submitting = false;
-          this.toastrService.success('Password updated', 'Successfully');
-          this.dialogRef.close(true);
-        },
-        error: (err) => {
-          this.submitting = false;
-          this.toastrService.error(
-            err?.error?.message ?? err?.message ?? 'Failed to update password',
-            'Error',
-          );
-        },
-      });
+    this.userService.updateOwnPassword({ oldPassword, newPassword }).subscribe({
+      next: () => {
+        this.submitting = false;
+        this.toastrService.success('Password updated', 'Successfully');
+        this.dialogRef.close(true);
+      },
+      error: (err) => {
+        this.submitting = false;
+        this.toastrService.error(
+          err?.error?.message ?? err?.message ?? 'Failed to update password',
+          'Error',
+        );
+      },
+    });
   }
 
   cancel() {

--- a/src/app/view/user-profile/user-profile.component.ts
+++ b/src/app/view/user-profile/user-profile.component.ts
@@ -1,6 +1,10 @@
 import { Component } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
-import { AdminService, UserService, OrganizationService } from '../../auth/services';
+import {
+  AdminService,
+  UserService,
+  OrganizationService,
+} from '../../auth/services';
 import { Router, ActivatedRoute } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { MatDialog } from '@angular/material/dialog';
@@ -97,7 +101,7 @@ export class UserProfileComponent {
   onDeleteAccount() {
     const confirmed = window.confirm(
       'Are you sure you want to permanently delete your account?\n\n' +
-      'This action cannot be undone. All your data will be lost.',
+        'This action cannot be undone. All your data will be lost.',
     );
     if (!confirmed) return;
 


### PR DESCRIPTION
\`pnpm prettier\` on \`develop\` fails on 44 TypeScript files — drift that's accumulated over time because \`prettier:fix\` hadn't been run before pushes. As a result, every open drec-ui PR currently fails the \`lint-prettier\` CI check regardless of its own content.

This PR runs \`pnpm run prettier:fix\` + manual fixes on two files the repo's glob missed (\`shared/satellite-preview/\` and \`auth/services/bulk-upload.service.ts\`). Pure whitespace/indentation/quote-normalization; no behavior change.

After this lands, \`pnpm prettier\` exits clean on develop and each open drec-ui PR (#453, #454, #455) should go green once rebased.